### PR TITLE
PIN 5269: Purpose event consumer

### DIFF
--- a/packages/clients/operations/src/types.ts
+++ b/packages/clients/operations/src/types.ts
@@ -248,3 +248,10 @@ export type ApiSaveMissingTracingParams = ZodiosPathParamsByPath<
   "post",
   "/tenants/:tenantId/tracings/missing"
 >;
+export type ApiSavePurposePayload = ZodiosBodyByPath<Api, "post", "/purposes">;
+
+export type ApiDeletePurposeParams = ZodiosPathParamsByPath<
+  Api,
+  "delete",
+  "/purposes/:purposeId"
+>;

--- a/packages/clients/operations/src/types.ts
+++ b/packages/clients/operations/src/types.ts
@@ -250,6 +250,18 @@ export type ApiSaveMissingTracingParams = ZodiosPathParamsByPath<
 >;
 export type ApiSavePurposePayload = ZodiosBodyByPath<Api, "post", "/purposes">;
 
+export type ApiSavePurposeResponse = ZodiosResponseByPath<
+  Api,
+  "post",
+  "/purposes"
+>;
+
+export type ApiSavePurposeHeaders = ZodiosHeaderParamsByPath<
+  Api,
+  "post",
+  "/purposes"
+>;
+
 export type ApiDeletePurposeParams = ZodiosPathParamsByPath<
   Api,
   "delete",

--- a/packages/commons/src/logging/logger.ts
+++ b/packages/commons/src/logging/logger.ts
@@ -6,8 +6,13 @@ export type LoggerMetadata = {
   serviceName?: string;
   correlationId?: string;
   messageId?: string | null | undefined;
-  purposeId?: string;
   tenantId?: string;
+  eventType?: string;
+  eventVersion?: number;
+  streamId?: string;
+  version?: number;
+  eserviceId?: string;
+  purposeId?: string;
 };
 
 const parsedLoggerConfig = LoggerConfig.safeParse(process.env);

--- a/packages/models/src/errors.ts
+++ b/packages/models/src/errors.ts
@@ -119,6 +119,8 @@ const errorCodes = {
   tracingNotFound: "9007",
   tracingCannotBeUpdated: "9008",
   kafkaMessageProcessError: "9009",
+  kafkaMessageValueError: "9010",
+  kafkaMessageMissingData: "9011",
 } as const;
 
 export type CommonErrorCodes = keyof typeof errorCodes;
@@ -161,6 +163,25 @@ export function kafkaMessageProcessError(
     detail: `Error while handling kafka message from topic : ${topic} - partition ${partition} - offset ${offset}. ${
       error ? parseErrorMessage(error) : ""
     }`,
+  });
+}
+
+export function kafkaMissingMessageValue(
+  topic: string,
+): InternalError<CommonErrorCodes> {
+  return new InternalError({
+    code: "kafkaMessageValueError",
+    detail: `Missing value message in kafka message from topic: ${topic}`,
+  });
+}
+
+export function kafkaMessageMissingData(
+  topic: string,
+  eventType: string,
+): InternalError<CommonErrorCodes> {
+  return new InternalError({
+    code: "kafkaMessageMissingData",
+    detail: `Missing data in kafka message from topic: ${topic} and event type: ${eventType}`,
   });
 }
 

--- a/packages/operations/open-api/api-tracing-operations-interop-v1.yaml
+++ b/packages/operations/open-api/api-tracing-operations-interop-v1.yaml
@@ -535,8 +535,8 @@ paths:
                 $ref: "#/components/schemas/Problem"
   /purposes:
     post:
-      summary: Save purposes
-      operationId: savePurposes
+      summary: Save purpose
+      operationId: savePurpose
       parameters:
         - in: header
           name: x-correlation-id
@@ -574,8 +574,8 @@ paths:
                 $ref: "#/components/schemas/Problem"
   /purposes/{purposeId}:
     delete:
-      summary: Delete purposes
-      operationId: deletePurposes
+      summary: Delete purpose
+      operationId: deletePurpose
       parameters:
         - in: header
           name: x-correlation-id

--- a/packages/operations/open-api/api-tracing-operations-interop-v1.yaml
+++ b/packages/operations/open-api/api-tracing-operations-interop-v1.yaml
@@ -8,6 +8,8 @@ tags:
     description: Operations related to tracings
   - name: Tenants
     description: Operations related to tenants
+  - name: Purposes
+    description: Operations related to purposes
 paths:
   /tracings/submit:
     post:
@@ -531,6 +533,86 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Problem"
+  /purposes:
+    post:
+      summary: Save purposes
+      operationId: savePurposes
+      parameters:
+        - in: header
+          name: x-correlation-id
+          required: true
+          schema:
+            $ref: "#/components/schemas/CorrelationId"
+      tags:
+        - Purposes
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SavePurposesRequest"
+      responses:
+        "204":
+          description: No content
+        "400":
+          description: The provided input data is invalid
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "404":
+          description: The requested resource could not be found on the server
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "500":
+          description: A managed error has occurred during the request elaboration
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+  /purposes/{purposeId}:
+    delete:
+      summary: Delete purposes
+      operationId: deletePurposes
+      parameters:
+        - in: header
+          name: x-correlation-id
+          required: true
+          schema:
+            $ref: "#/components/schemas/CorrelationId"
+        - name: purposeId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: The ID of the purpose
+      tags:
+        - Purposes
+      responses:
+        "204":
+          description: No content
+        "400":
+          description: The provided input data is invalid
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "404":
+          description: The requested resource could not be found on the server
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "500":
+          description: A managed error has occurred during the request elaboration
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+
 
 components:
   schemas:
@@ -735,6 +817,23 @@ components:
           type: number
         previousState:
           $ref: "#/components/schemas/TracingState"
+    SavePurposesRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        consumer_id:
+          type: string
+          format: uuid
+        eservice_id:
+          type: string
+          format: uuid
+        purpose_title:
+          type: string
+          format: string
+      required:
+        - date
     Problem:
       properties:
         type:

--- a/packages/operations/src/routers/operationsRouter.ts
+++ b/packages/operations/src/routers/operationsRouter.ts
@@ -246,6 +246,26 @@ const operationsRouter = (
     },
   );
 
+  operationsRouter.post("/purposes", async (req, res) => {
+    try {
+      await operationsService.savePurpose(req.body, logger(req.ctx));
+      return res.status(204).end();
+    } catch (error) {
+      const errorRes = makeApiProblem(error, errorMapper, logger(req.ctx));
+      return res.status(errorRes.status).json(errorRes).end();
+    }
+  });
+
+  operationsRouter.delete("/purposes/:purposeId", async (req, res) => {
+    try {
+      await operationsService.deletePurpose(req.params, logger(req.ctx));
+      return res.status(204).end();
+    } catch (error) {
+      const errorRes = makeApiProblem(error, errorMapper, logger(req.ctx));
+      return res.status(errorRes.status).json(errorRes).end();
+    }
+  });
+
   return operationsRouter;
 };
 

--- a/packages/operations/src/services/db/dbService.ts
+++ b/packages/operations/src/services/db/dbService.ts
@@ -8,6 +8,7 @@ import {
 } from "pagopa-interop-tracing-models";
 import { DB, DateUnit, truncatedTo } from "pagopa-interop-tracing-commons";
 import {
+  Purpose,
   PurposeError,
   Tracing,
   UpdateTracingState,
@@ -387,6 +388,39 @@ export function dbServiceBuilder(db: DB) {
         };
       } catch (error) {
         throw dbServiceErrorMapper("getTenantsWithMissingTracings", error);
+      }
+    },
+
+    async savePurpose(purpose: Purpose) {
+      try {
+        const upsertPurposeQuery = `
+          INSERT INTO tracing.purposes (id, consumer_id, eservice_id, purpose_title)
+          VALUES ($1, $2, $3, $4)
+          ON CONFLICT (id) 
+          DO UPDATE SET consumer_id = $2, eservice_id = $3, purpose_title = $4
+          RETURNING id;
+        `;
+
+        return await db.one(upsertPurposeQuery, [
+          purpose.id,
+          purpose.consumer_id,
+          purpose.eservice_id,
+          purpose.purpose_title,
+        ]);
+      } catch (error) {
+        throw dbServiceErrorMapper("savePurpose", error);
+      }
+    },
+
+    async deletePurpose(purposeId: string) {
+      try {
+        const deletePurposeQuery = `
+          DELETE FROM tracing.purposes WHERE id = $1;
+        `;
+
+        await db.none(deletePurposeQuery, [purposeId]);
+      } catch (error) {
+        throw dbServiceErrorMapper("deletePurpose", error);
       }
     },
   };

--- a/packages/operations/src/services/operationsService.ts
+++ b/packages/operations/src/services/operationsService.ts
@@ -25,6 +25,8 @@ import {
   ApiSaveMissingTracingPayload,
   ApiSaveMissingTracingResponse,
   ApiDeletePurposesErrorsResponse,
+  ApiSavePurposePayload,
+  ApiDeletePurposeParams,
 } from "pagopa-interop-tracing-operations-client";
 import { Logger } from "pagopa-interop-tracing-commons";
 import { DBService } from "./db/dbService.js";
@@ -42,6 +44,7 @@ import {
   TracingsContentResponse,
 } from "../model/domain/tracing.js";
 import { tracingCannotBeCancelled } from "../model/domain/errors.js";
+import { PurposeSchema } from "../model/domain/db.js";
 
 export function operationsServiceBuilder(dbService: DBService) {
   return {
@@ -290,6 +293,23 @@ export function operationsServiceBuilder(dbService: DBService) {
         results: parsedTracingErrors.data,
         totalCount: data.totalCount,
       };
+    },
+
+    async savePurpose(purposePayload: ApiSavePurposePayload, logger: Logger) {
+      logger.info(`Saving purpose with id ${purposePayload.id}`);
+      const purpose = PurposeSchema.safeParse(purposePayload);
+      if (purpose.error) {
+        throw new Error(
+          `Unable to parse purpose: ${JSON.stringify(purpose.error.message)}`,
+        );
+      }
+      return await dbService.savePurpose(purpose.data);
+    },
+
+    async deletePurpose(params: ApiDeletePurposeParams, logger: Logger) {
+      const purposeId = params.purposeId;
+      logger.info(`Deleting purpose with id ${purposeId}`);
+      return await dbService.deletePurpose(purposeId);
     },
   };
 }

--- a/packages/operations/src/services/operationsService.ts
+++ b/packages/operations/src/services/operationsService.ts
@@ -297,12 +297,15 @@ export function operationsServiceBuilder(dbService: DBService) {
 
     async savePurpose(purposePayload: ApiSavePurposePayload, logger: Logger) {
       logger.info(`Saving purpose with id ${purposePayload.id}`);
+
       const purpose = PurposeSchema.safeParse(purposePayload);
-      if (purpose.error) {
+
+      if (!purpose.success) {
         throw new Error(
           `Unable to parse purpose: ${JSON.stringify(purpose.error.message)}`,
         );
       }
+
       return await dbService.savePurpose(purpose.data);
     },
 

--- a/packages/operations/test/operationsService.test.ts
+++ b/packages/operations/test/operationsService.test.ts
@@ -1206,7 +1206,7 @@ describe("database test", () => {
           eservice_id: eservice_id,
           purpose_title: "Purpose Title",
         };
-        addPurpose(purposePayload, dbInstance);
+        await addPurpose(purposePayload, dbInstance);
         const purpose_title = "New Purpose Title";
 
         const operationsService = operationsServiceBuilder(dbService);

--- a/packages/operations/test/operationsService.test.ts
+++ b/packages/operations/test/operationsService.test.ts
@@ -1178,9 +1178,63 @@ describe("database test", () => {
         await operationsService.deletePurposesErrors(genericLogger);
 
         const purposesErrors = await findPurposeErrors(dbInstance);
-        console.log("purposesErrors", purposesErrors);
 
         expect(purposesErrors.length).toBe(0);
+      });
+    });
+
+    describe("savePurpose", () => {
+      it("should save a purpose successfully", async () => {
+        const purposePayload = {
+          id: generateId<PurposeId>(),
+          consumer_id: tenantId,
+          eservice_id: eservice_id,
+          purpose_title: "New Purpose Title",
+        };
+
+        const operationsService = operationsServiceBuilder(dbService);
+
+        expect(
+          async () =>
+            await operationsService.savePurpose(purposePayload, genericLogger),
+        ).not.toThrowError();
+      });
+
+      it("should throw an error if the purpose payload is invalid", async () => {
+        const invalidPurposePayload = {
+          id: "invalid_id_format",
+          purpose_title: "New Purpose Title",
+        };
+
+        const logger = genericLogger;
+
+        const operationsService = operationsServiceBuilder(dbService);
+
+        await expect(
+          operationsService.savePurpose(invalidPurposePayload, logger),
+        ).rejects.toThrowError(/Unable to parse purpose/);
+      });
+    });
+    describe("deletePurpose", () => {
+      it("should delete a purpose successfully", async () => {
+        const purposeId = generateId<PurposeId>();
+        const logger = genericLogger;
+        const operationsService = operationsServiceBuilder(dbService);
+
+        expect(
+          async () =>
+            await operationsService.deletePurpose({ purposeId }, logger),
+        ).not.toThrowError();
+      });
+
+      it("should throw an error if deleting a non-existent purpose", async () => {
+        const purposeId = "non_existent_id";
+        const logger = genericLogger;
+        const operationsService = operationsServiceBuilder(dbService);
+
+        await expect(
+          operationsService.deletePurpose({ purposeId }, logger),
+        ).rejects.toThrowError(/deletePurpose/);
       });
     });
   });

--- a/packages/operations/test/operationsService.test.ts
+++ b/packages/operations/test/operationsService.test.ts
@@ -1236,7 +1236,7 @@ describe("database test", () => {
     describe("deletePurpose", () => {
       it("should delete a purpose successfully", async () => {
         const purposeId = generateId<PurposeId>();
-        let purposePayload = {
+        const purposePayload = {
           id: purposeId,
           consumer_id: tenantId,
           eservice_id: eservice_id,

--- a/packages/operations/test/utils.ts
+++ b/packages/operations/test/utils.ts
@@ -85,6 +85,19 @@ export async function findPurposeErrors(db: DB): Promise<PurposeError[]> {
   return await db.any<PurposeError>(selectPurposeErrorQuery);
 }
 
+export async function findPurposeById(
+  id: string,
+  db: DB,
+): Promise<Purpose | null> {
+  const selectPurposeQuery = `
+      SELECT * 
+      FROM tracing.purposes 
+      WHERE id = $1
+    `;
+
+  return await db.oneOrNone<Purpose | null>(selectPurposeQuery, [id]);
+}
+
 export async function addEservice(
   eServiceValues: { eservice_id: string; producer_id: string },
   db: DB,

--- a/packages/purpose-event-consumer/.env
+++ b/packages/purpose-event-consumer/.env
@@ -1,0 +1,12 @@
+APPLICATION_NAME="interop-tracing-purpose-event-consumer"
+LOG_LEVEL=info
+
+API_OPERATIONS_BASEURL="http://localhost:3000"
+
+KAFKA_CLIENT_ID="key"
+KAFKA_GROUP_ID="group-id"
+KAFKA_BROKERS="localhost:9092"
+KAFKA_DISABLE_AWS_IAM_AUTH="true"
+KAFKA_TOPIC="purpose"
+
+AWS_REGION="eu-central-1"

--- a/packages/purpose-event-consumer/.eslintrc
+++ b/packages/purpose-event-consumer/.eslintrc
@@ -1,0 +1,37 @@
+{
+  "parser": "@typescript-eslint/parser",
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended",
+    "prettier",
+    "plugin:prettier/recommended"
+  ],
+  "parserOptions": {
+    "project": "./tsconfig.json"
+  },
+  "rules": {
+    "@typescript-eslint/switch-exhaustiveness-check": "error",
+    "default-case": "off",
+    "prefer-arrow/prefer-arrow-functions": "off",
+    "eqeqeq": [
+      "error",
+      "smart"
+    ],
+    "@typescript-eslint/consistent-type-definitions": "off",
+    "sort-keys": "off",
+    "functional/prefer-readonly-type": "off",
+    "@typescript-eslint/no-shadow": "off",
+    "extra-rules/no-commented-out-code": "off",
+    "max-lines-per-function": "off",
+    "@typescript-eslint/naming-convention": "off",
+    "@typescript-eslint/no-use-before-define": "off",
+    "@typescript-eslint/await-thenable": "off"
+  },
+  "ignorePatterns": [
+    ".eslintrc",
+    "**/src/model/generated/*.ts",
+    "vitest.config.ts",
+    "**/dist"
+  ]
+}

--- a/packages/purpose-event-consumer/Dockerfile
+++ b/packages/purpose-event-consumer/Dockerfile
@@ -1,0 +1,32 @@
+FROM node:20.11.1-slim as build
+
+RUN corepack enable
+
+WORKDIR /app
+COPY package.json /app/
+COPY pnpm-lock.yaml /app/
+COPY pnpm-workspace.yaml /app/
+
+COPY ./packages/purpose-event-consumer/package.json /app/packages/purpose-event-consumer/package.json
+COPY ./packages/commons/package.json /app/packages/commons/package.json
+COPY ./packages/models/package.json /app/packages/models/package.json
+COPY ./packages/clients/operations/package.json /app/packages/clients/operations/package.json
+COPY ./packages/kafka-connector/package.json /app/packages/kafka-connector/package.json
+
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
+
+COPY tsconfig.json /app/
+COPY turbo.json /app/
+COPY ./packages/purpose-event-consumer /app/packages/purpose-event-consumer
+COPY ./packages/operations/open-api /app/packages/operations/open-api
+COPY ./packages/commons /app/packages/commons
+COPY ./packages/kafka-connector /app/packages/kafka-connector
+COPY ./packages/models /app/packages/models
+COPY ./packages/clients/operations /app/packages/clients/operations
+
+RUN pnpm build
+RUN rm -rf /app/packages/purpose-event-consumer/dist/test
+
+WORKDIR /app/packages/purpose-event-consumer
+
+CMD [ "node", "." ]

--- a/packages/purpose-event-consumer/package.json
+++ b/packages/purpose-event-consumer/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "pagopa-interop-tracing-purpose-event-consumer",
+  "version": "1.0.0",
+  "description": "PagoPA Interop Tracing purpose event consumer",
+  "main": "dist",
+  "type": "module",
+  "scripts": {
+    "test": "vitest --config ./test/vitest.config.ts",
+    "test:it": "vitest db --config ./test/vitest.config.ts",
+    "lint": "eslint . --ext .ts,.tsx",
+    "lint:autofix": "eslint . --ext .ts,.tsx --fix",
+    "format:check": "prettier --check src",
+    "format:write": "prettier --write src",
+    "start": "node --watch --no-warnings --loader ts-node/esm -r 'dotenv-flow/config' ./src/index.ts",
+    "build": "tsc",
+    "check": "tsc --project tsconfig.check.json"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@pagopa/interop-outbound-models": "1.0.3",
+    "@zodios/core": "10.9.6",
+    "dotenv-flow": "3.3.0",
+    "kafka-connector": "workspace:*",
+    "kafkajs": "2.2.4",
+    "pagopa-interop-tracing-commons": "workspace:*",
+    "pagopa-interop-tracing-models": "workspace:*",
+    "pagopa-interop-tracing-operations-client": "workspace:*",
+    "ts-pattern": "5.2.0",
+    "uuid": "10.0.0",
+    "zod": "3.23.8",
+    "axios": "1.6.7",
+    "@tsconfig/node-lts": "20.1.0"
+  },
+  "devDependencies": {
+    "@types/uuid": "9.0.8",
+    "@types/dotenv-flow": "3.3.3",
+    "@types/node": "20.3.1",
+    "@typescript-eslint/eslint-plugin": "6.21.0",
+    "@typescript-eslint/parser": "6.21.0",
+    "eslint": "8.49.0",
+    "eslint-config-prettier": "9.0.0",
+    "eslint-plugin-prettier": "5.0.0",
+    "prettier": "3.0.3",
+    "ts-node": "10.9.2",
+    "typescript": "5.5.2",
+    "vitest": "0.33.0"
+  }
+}

--- a/packages/purpose-event-consumer/src/handlers/index.ts
+++ b/packages/purpose-event-consumer/src/handlers/index.ts
@@ -1,0 +1,2 @@
+export * from "./messageHandlerV1.js";
+export * from "./messageHandlerV2.js";

--- a/packages/purpose-event-consumer/src/handlers/messageHandlerV1.ts
+++ b/packages/purpose-event-consumer/src/handlers/messageHandlerV1.ts
@@ -1,0 +1,49 @@
+import { PurposeEventV1 } from "@pagopa/interop-outbound-models";
+import { Logger, AppContext } from "pagopa-interop-tracing-commons";
+import { P, match } from "ts-pattern";
+import { config } from "../utilities/config.js";
+import { OperationsService } from "../services/operationsService.js";
+import {
+  correlationIdToHeader,
+  kafkaMessageMissingData,
+} from "pagopa-interop-tracing-models";
+
+export async function handleMessageV1(
+  event: PurposeEventV1,
+  operationsService: OperationsService,
+  ctx: AppContext,
+  logger: Logger,
+): Promise<void> {
+  await match(event)
+    .with(
+      {
+        type: P.union("PurposeVersionActivated"),
+      },
+      async (evt) => {
+        if (!evt.data.purpose) {
+          throw kafkaMessageMissingData(config.kafkaTopic, event.type);
+        }
+
+        const { purpose } = evt.data;
+
+        await operationsService.savePurpose(
+          { ...correlationIdToHeader(ctx.correlationId) },
+          {
+            id: purpose.id,
+            consumer_id: purpose.consumerId,
+            eservice_id: purpose.eserviceId,
+            purpose_title: purpose.title,
+          },
+          logger,
+        );
+      },
+    )
+    .with(
+      {
+        type: P.union("PurposeCreated", "PurposeVersionArchived"),
+      },
+      async () => {
+        logger.info(`Skip event (not relevant)`);
+      },
+    );
+}

--- a/packages/purpose-event-consumer/src/handlers/messageHandlerV1.ts
+++ b/packages/purpose-event-consumer/src/handlers/messageHandlerV1.ts
@@ -65,7 +65,7 @@ export async function handleMessageV1(
         ),
       },
       async () => {
-        logger.info(`Skip event (not relevant)`);
+        logger.info(`Skip event ${event.type} (not relevant)`);
       },
     )
     .exhaustive();

--- a/packages/purpose-event-consumer/src/handlers/messageHandlerV2.ts
+++ b/packages/purpose-event-consumer/src/handlers/messageHandlerV2.ts
@@ -40,10 +40,29 @@ export async function handleMessageV2(
 
     .with(
       {
-        type: P.union("PurposeArchived", "PurposeCloned"),
+        type: P.union(
+          "NewPurposeVersionActivated",
+          "PurposeVersionActivated",
+          "PurposeVersionUnsuspendedByProducer",
+          "PurposeVersionUnsuspendedByConsumer",
+          "PurposeVersionSuspendedByProducer",
+          "PurposeVersionSuspendedByConsumer",
+          "PurposeVersionOverQuotaUnsuspended",
+          "PurposeArchived",
+          "PurposeAdded",
+          "DraftPurposeUpdated",
+          "PurposeWaitingForApproval",
+          "DraftPurposeDeleted",
+          "WaitingForApprovalPurposeDeleted",
+          "NewPurposeVersionWaitingForApproval",
+          "WaitingForApprovalPurposeVersionDeleted",
+          "PurposeVersionRejected",
+          "PurposeCloned",
+        ),
       },
       async () => {
         logger.info(`Skip event (not relevant)`);
       },
-    );
+    )
+    .exhaustive();
 }

--- a/packages/purpose-event-consumer/src/handlers/messageHandlerV2.ts
+++ b/packages/purpose-event-consumer/src/handlers/messageHandlerV2.ts
@@ -1,4 +1,8 @@
-import { PurposeEventV2 } from "@pagopa/interop-outbound-models";
+import {
+  PurposeEventV2,
+  PurposeStateV2,
+  PurposeVersionV2,
+} from "@pagopa/interop-outbound-models";
 import { Logger, AppContext } from "pagopa-interop-tracing-commons";
 import {
   correlationIdToHeader,
@@ -7,6 +11,7 @@ import {
 import { P, match } from "ts-pattern";
 import { config } from "../utilities/config.js";
 import { OperationsService } from "../services/operationsService.js";
+import { kafkaInvalidVersion } from "../models/domain/errors.js";
 
 export async function handleMessageV2(
   event: PurposeEventV2,
@@ -20,9 +25,13 @@ export async function handleMessageV2(
         type: P.union("PurposeActivated"),
       },
       async (evt) => {
-        const { purpose } = evt.data;
-        if (!purpose) {
+        if (!evt.data.purpose) {
           throw kafkaMessageMissingData(config.kafkaTopic, event.type);
+        }
+        const { purpose } = evt.data;
+
+        if (hasPurposeVersionInAValidState(purpose.versions)) {
+          throw kafkaInvalidVersion();
         }
 
         await operationsService.savePurpose(
@@ -66,3 +75,46 @@ export async function handleMessageV2(
     )
     .exhaustive();
 }
+
+const validVersionInVersionsV2 = (
+  purposeVersions: PurposeVersionV2[],
+): { versionId: string; state: string } | undefined =>
+  match(purposeVersions)
+    .when(
+      (versions) =>
+        versions.some((version) => version.state === PurposeStateV2.ACTIVE),
+      () => getVersionBy(PurposeStateV2.ACTIVE, purposeVersions),
+    )
+    .when(
+      (versions) =>
+        versions.some((version) => version.state === PurposeStateV2.SUSPENDED),
+      () => getVersionBy(PurposeStateV2.SUSPENDED, purposeVersions),
+    )
+    .when(
+      (versions) =>
+        versions.some((version) => version.state === PurposeStateV2.ARCHIVED),
+      () => getVersionBy(PurposeStateV2.ARCHIVED, purposeVersions),
+    )
+    .otherwise(() => undefined);
+
+function getVersionBy(
+  purposeState: PurposeStateV2,
+  purposeVersions: PurposeVersionV2[],
+): {
+  versionId: string;
+  state: string;
+} {
+  return purposeVersions
+    .filter((version) => version.state === purposeState)
+    .reduce(
+      (obj, version) => {
+        const { id, state } = version;
+        return { ...obj, versionId: id, state: PurposeStateV2[state] };
+      },
+      {} as { versionId: string; state: string },
+    );
+}
+
+const hasPurposeVersionInAValidState = (
+  versions: PurposeVersionV2[],
+): boolean => !validVersionInVersionsV2(versions);

--- a/packages/purpose-event-consumer/src/handlers/messageHandlerV2.ts
+++ b/packages/purpose-event-consumer/src/handlers/messageHandlerV2.ts
@@ -72,7 +72,7 @@ export async function handleMessageV2(
         ),
       },
       async () => {
-        logger.info(`Skip event (not relevant)`);
+        logger.info(`Skip event ${event.type} (not relevant)`);
       },
     )
     .exhaustive();

--- a/packages/purpose-event-consumer/src/handlers/messageHandlerV2.ts
+++ b/packages/purpose-event-consumer/src/handlers/messageHandlerV2.ts
@@ -11,7 +11,7 @@ import {
 import { P, match } from "ts-pattern";
 import { config } from "../utilities/config.js";
 import { OperationsService } from "../services/operationsService.js";
-import { kafkaInvalidVersion } from "../models/domain/errors.js";
+import { errorInvalidVersion } from "../models/domain/errors.js";
 
 export async function handleMessageV2(
   event: PurposeEventV2,
@@ -31,7 +31,9 @@ export async function handleMessageV2(
         const { purpose } = evt.data;
 
         if (hasPurposeVersionInAValidState(purpose.versions)) {
-          throw kafkaInvalidVersion();
+          throw errorInvalidVersion(
+            `Missing valid version within versions Array for purposeId ${purpose.id}`,
+          );
         }
 
         await operationsService.savePurpose(

--- a/packages/purpose-event-consumer/src/handlers/messageHandlerV2.ts
+++ b/packages/purpose-event-consumer/src/handlers/messageHandlerV2.ts
@@ -1,0 +1,49 @@
+import { PurposeEventV2 } from "@pagopa/interop-outbound-models";
+import { Logger, AppContext } from "pagopa-interop-tracing-commons";
+import {
+  correlationIdToHeader,
+  kafkaMessageMissingData,
+} from "pagopa-interop-tracing-models";
+import { P, match } from "ts-pattern";
+import { config } from "../utilities/config.js";
+import { OperationsService } from "../services/operationsService.js";
+
+export async function handleMessageV2(
+  event: PurposeEventV2,
+  operationsService: OperationsService,
+  ctx: AppContext,
+  logger: Logger,
+): Promise<void> {
+  await match(event)
+    .with(
+      {
+        type: P.union("PurposeActivated"),
+      },
+      async (evt) => {
+        const { purpose } = evt.data;
+        if (!purpose) {
+          throw kafkaMessageMissingData(config.kafkaTopic, event.type);
+        }
+
+        await operationsService.savePurpose(
+          { ...correlationIdToHeader(ctx.correlationId) },
+          {
+            id: purpose.id,
+            eserviceId: purpose.eserviceId,
+            consumerId: purpose.consumerId,
+            purpose_title: purpose.title,
+          },
+          logger,
+        );
+      },
+    )
+
+    .with(
+      {
+        type: P.union("PurposeArchived", "PurposeCloned"),
+      },
+      async () => {
+        logger.info(`Skip event (not relevant)`);
+      },
+    );
+}

--- a/packages/purpose-event-consumer/src/index.ts
+++ b/packages/purpose-event-consumer/src/index.ts
@@ -1,0 +1,18 @@
+import { runConsumer } from "kafka-connector";
+import { config } from "./utilities/config.js";
+import { createApiClient } from "pagopa-interop-tracing-operations-client";
+import {
+  OperationsService,
+  operationsServiceBuilder,
+} from "./services/operationsService.js";
+import { processMessage } from "./messagesHandler.js";
+
+const operationsApiClient = createApiClient(config.operationsBaseUrl);
+const operationsService: OperationsService =
+  operationsServiceBuilder(operationsApiClient);
+
+await runConsumer(
+  config,
+  [config.kafkaTopic],
+  processMessage(operationsService),
+);

--- a/packages/purpose-event-consumer/src/messagesHandler.ts
+++ b/packages/purpose-event-consumer/src/messagesHandler.ts
@@ -1,0 +1,51 @@
+import { AppContext, logger } from "pagopa-interop-tracing-commons";
+import { kafkaMissingMessageValue } from "pagopa-interop-tracing-models";
+import { OperationsService } from "./services/operationsService.js";
+import { errorMapper } from "./utilities/errorMapper.js";
+import { config } from "./utilities/config.js";
+import { v4 as uuidv4 } from "uuid";
+import { EachMessagePayload } from "kafkajs";
+import { match } from "ts-pattern";
+import { decodeOutboundPurposeEvent } from "@pagopa/interop-outbound-models";
+import { handleMessageV1, handleMessageV2 } from "./handlers/index.js";
+
+export function processMessage(
+  service: OperationsService,
+): ({ message, partition }: EachMessagePayload) => Promise<void> {
+  return async ({ message, partition }: EachMessagePayload): Promise<void> => {
+    const ctx: AppContext = {
+      serviceName: config.applicationName,
+      correlationId: uuidv4(),
+    };
+
+    try {
+      if (!message.value) {
+        throw kafkaMissingMessageValue(config.kafkaTopic);
+      }
+      const purposeEvent = decodeOutboundPurposeEvent(message.value.toString());
+
+      const loggerInstance = logger({
+        ...ctx,
+        eventType: purposeEvent.type,
+        eventVersion: purposeEvent.event_version,
+        streamId: purposeEvent.stream_id,
+        version: purposeEvent.version,
+      });
+
+      await match(purposeEvent)
+        .with({ event_version: 1 }, (event) =>
+          handleMessageV1(event, service, ctx, loggerInstance),
+        )
+        .with({ event_version: 2 }, (event) =>
+          handleMessageV2(event, service, ctx, loggerInstance),
+        )
+        .exhaustive();
+
+      loggerInstance.info(
+        `Message was processed. Partition number: ${partition}. Offset: ${message.offset}`,
+      );
+    } catch (error: unknown) {
+      throw errorMapper(error, logger(ctx));
+    }
+  };
+}

--- a/packages/purpose-event-consumer/src/models/domain/errors.ts
+++ b/packages/purpose-event-consumer/src/models/domain/errors.ts
@@ -1,0 +1,14 @@
+import { InternalError } from "pagopa-interop-tracing-models";
+
+export const errorCodes = {
+  errorSavePurpose: "ERROR_SAVE_PURPOSE",
+} as const;
+
+export type ErrorCodes = keyof typeof errorCodes;
+
+export function errorSavePurpose(detail: string): InternalError<ErrorCodes> {
+  return new InternalError({
+    detail: `${detail}`,
+    code: "errorSavePurpose",
+  });
+}

--- a/packages/purpose-event-consumer/src/models/domain/errors.ts
+++ b/packages/purpose-event-consumer/src/models/domain/errors.ts
@@ -14,9 +14,9 @@ export function errorSavePurpose(detail: string): InternalError<ErrorCodes> {
   });
 }
 
-export function kafkaInvalidVersion(): InternalError<ErrorCodes> {
+export function errorInvalidVersion(detail: string): InternalError<ErrorCodes> {
   return new InternalError({
+    detail: `${detail}`,
     code: "noVersionsInValidState",
-    detail: `Missing valid version within versions Array`,
   });
 }

--- a/packages/purpose-event-consumer/src/models/domain/errors.ts
+++ b/packages/purpose-event-consumer/src/models/domain/errors.ts
@@ -2,6 +2,7 @@ import { InternalError } from "pagopa-interop-tracing-models";
 
 export const errorCodes = {
   errorSavePurpose: "ERROR_SAVE_PURPOSE",
+  noVersionsInValidState: "NO_VERSION_IN_VALID_STATE",
 } as const;
 
 export type ErrorCodes = keyof typeof errorCodes;
@@ -10,5 +11,12 @@ export function errorSavePurpose(detail: string): InternalError<ErrorCodes> {
   return new InternalError({
     detail: `${detail}`,
     code: "errorSavePurpose",
+  });
+}
+
+export function kafkaInvalidVersion(): InternalError<ErrorCodes> {
+  return new InternalError({
+    code: "noVersionsInValidState",
+    detail: `Missing valid version within versions Array`,
   });
 }

--- a/packages/purpose-event-consumer/src/models/domain/model.ts
+++ b/packages/purpose-event-consumer/src/models/domain/model.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const PurposeEntity = z.object({
+  purposeId: z.string(),
+  purposeVersionId: z.string(),
+  eserviceId: z.string(),
+  consumerId: z.string(),
+  purposeState: z.string(),
+  eventStreamId: z.string(),
+  eventVersionId: z.number(),
+  tmstInsert: z.string().nullable().optional(),
+  tmstLastEdit: z.string().nullable().optional(),
+});
+
+export type PurposeEntity = z.infer<typeof PurposeEntity>;

--- a/packages/purpose-event-consumer/src/services/operationsService.ts
+++ b/packages/purpose-event-consumer/src/services/operationsService.ts
@@ -1,0 +1,43 @@
+import { ZodiosInstance } from "@zodios/core";
+import {
+  Api,
+  ApiSavePurposeHeaders,
+  ApiSavePurposePayload,
+  ApiSavePurposeResponse,
+} from "pagopa-interop-tracing-operations-client";
+import { Logger } from "pagopa-interop-tracing-commons";
+import { errorSavePurpose } from "../models/domain/errors.js";
+
+export const operationsServiceBuilder = (
+  operationsApiClient: ZodiosInstance<Api>,
+) => {
+  return {
+    async savePurpose(
+      headers: ApiSavePurposeHeaders,
+      data: ApiSavePurposePayload,
+      logger: Logger,
+    ): Promise<ApiSavePurposeResponse> {
+      try {
+        await operationsApiClient.savePurpose(
+          {
+            id: data.id,
+            consumer_id: data.consumer_id,
+            eservice_id: data.eservice_id,
+            purpose_title: data.purpose_title,
+          },
+          {
+            headers,
+          },
+        );
+
+        logger.info(`purpose saved with purposeId: ${data.id}.`);
+      } catch (error: unknown) {
+        throw errorSavePurpose(
+          `Error saving purpose: ${data.id}, Details: ${error}`,
+        );
+      }
+    },
+  };
+};
+
+export type OperationsService = ReturnType<typeof operationsServiceBuilder>;

--- a/packages/purpose-event-consumer/src/utilities/config.ts
+++ b/packages/purpose-event-consumer/src/utilities/config.ts
@@ -1,0 +1,28 @@
+import {
+  LoggerConfig,
+  KafkaConsumerConfig,
+  KafkaTopicConfig,
+} from "pagopa-interop-tracing-commons";
+import { z } from "zod";
+
+const eServiceEventConsumerConfig = LoggerConfig.and(KafkaConsumerConfig)
+  .and(KafkaTopicConfig)
+  .and(
+    z
+      .object({
+        APPLICATION_NAME: z.string(),
+        API_OPERATIONS_BASEURL: z.string(),
+      })
+      .transform((c) => ({
+        applicationName: c.APPLICATION_NAME,
+        operationsBaseUrl: c.API_OPERATIONS_BASEURL,
+      })),
+  );
+
+export type EserviceEventConsumerConfig = z.infer<
+  typeof eServiceEventConsumerConfig
+>;
+
+export const config: EserviceEventConsumerConfig = {
+  ...eServiceEventConsumerConfig.parse(process.env),
+};

--- a/packages/purpose-event-consumer/src/utilities/errorMapper.ts
+++ b/packages/purpose-event-consumer/src/utilities/errorMapper.ts
@@ -1,0 +1,21 @@
+import {
+  CommonErrorCodes,
+  InternalError,
+  genericInternalError,
+} from "pagopa-interop-tracing-models";
+import { P, match } from "ts-pattern";
+import { ErrorCodes } from "../models/domain/errors.js";
+import { Logger } from "pagopa-interop-tracing-commons";
+
+type LocalErrorCodes = ErrorCodes | CommonErrorCodes;
+
+export const errorMapper = (error: unknown, logger: Logger) =>
+  match<unknown, InternalError<LocalErrorCodes>>(error)
+    .with(P.instanceOf(InternalError<LocalErrorCodes>), (error) => {
+      logger.error(error);
+      throw error;
+    })
+    .otherwise((error: unknown) => {
+      logger.error(error);
+      throw genericInternalError(`${error}`);
+    });

--- a/packages/purpose-event-consumer/test/messageHandlerV1.test.ts
+++ b/packages/purpose-event-consumer/test/messageHandlerV1.test.ts
@@ -55,8 +55,6 @@ describe("Operations service test", () => {
         generateID(),
       );
 
-      vi.spyOn(apiClient, "savePurpose").mock;
-
       expect(
         async () =>
           await handleMessageV1(

--- a/packages/purpose-event-consumer/test/messageHandlerV1.test.ts
+++ b/packages/purpose-event-consumer/test/messageHandlerV1.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+import { createApiClient } from "pagopa-interop-tracing-operations-client";
+import {
+  OperationsService,
+  operationsServiceBuilder,
+} from "../src/services/operationsService.js";
+import { config } from "../src/utilities/config.js";
+import { createPurposeActivatedEventV1, generateID } from "./utils.js";
+import { v4 as uuidv4 } from "uuid";
+import { AppContext, genericLogger } from "pagopa-interop-tracing-commons";
+import { kafkaMessageMissingData } from "pagopa-interop-tracing-models";
+import { handleMessageV1 } from "../src/handlers/messageHandlerV1.js";
+import { PurposeVersionV1 } from "@pagopa/interop-outbound-models";
+
+const apiClient = createApiClient(config.operationsBaseUrl);
+
+describe("Operations service test", () => {
+  const operationsService: OperationsService =
+    operationsServiceBuilder(apiClient);
+
+  const ctx: AppContext = {
+    serviceName: config.applicationName,
+    correlationId: uuidv4(),
+  };
+
+  describe("PurposeActivated Event", () => {
+    it("save a new purpose for PurposeActivated event should return a successfully response", async () => {
+      const purposeId = generateID();
+      const purpose = {
+        id: purposeId,
+        eserviceId: "",
+        consumerId: "",
+        title: "",
+        versions: [] as unknown as PurposeVersionV1[],
+        description: "",
+        createdAt: BigInt(12321321),
+      };
+
+      const purposeV1Event = createPurposeActivatedEventV1(
+        purpose,
+        generateID(),
+      );
+
+      vi.spyOn(apiClient, "savePurpose").mockResolvedValueOnce(undefined);
+
+      expect(
+        async () =>
+          await handleMessageV1(
+            purposeV1Event,
+            operationsService,
+            ctx,
+            genericLogger,
+          ),
+      ).not.toThrowError();
+    });
+
+    it("save a new purpose for PurposeActivated event should return an exception kafkaMessageMissingData", async () => {
+      const purposeV1Event = createPurposeActivatedEventV1(
+        undefined,
+        generateID(),
+      );
+
+      await expect(
+        handleMessageV1(purposeV1Event, operationsService, ctx, genericLogger),
+      ).rejects.toThrow(
+        kafkaMessageMissingData(config.kafkaTopic, purposeV1Event.type),
+      );
+    });
+  });
+});

--- a/packages/purpose-event-consumer/test/messageHandlerV1.test.ts
+++ b/packages/purpose-event-consumer/test/messageHandlerV1.test.ts
@@ -22,7 +22,7 @@ import {
   PurposeV1,
   PurposeVersionV1,
 } from "@pagopa/interop-outbound-models";
-import { kafkaInvalidVersion } from "../src/models/domain/errors.js";
+import { errorInvalidVersion } from "../src/models/domain/errors.js";
 
 const apiClient = createApiClient(config.operationsBaseUrl);
 
@@ -135,7 +135,7 @@ describe("Operations service test", () => {
       }
     });
 
-    it("Should throw kafkaInvalidVersion if versions has no valid state", async () => {
+    it("Should throw errorInvalidVersion if versions has no valid state", async () => {
       const mockPurposeV1 = getMockPurpose() as PurposeV1;
       const purpose: PurposeV1 = {
         ...mockPurposeV1,
@@ -155,7 +155,11 @@ describe("Operations service test", () => {
             ctx,
             genericLogger,
           ),
-      ).rejects.toThrow(kafkaInvalidVersion());
+      ).rejects.toThrow(
+        errorInvalidVersion(
+          `Missing valid version within versions Array for purposeId ${purpose.id}`,
+        ),
+      );
     });
   });
 });

--- a/packages/purpose-event-consumer/test/messageHandlerV1.test.ts
+++ b/packages/purpose-event-consumer/test/messageHandlerV1.test.ts
@@ -35,8 +35,8 @@ describe("Operations service test", () => {
     correlationId: uuidv4(),
   };
 
-  describe("PurposeActivated Event", () => {
-    it("save a new purpose for PurposeActivated event should return a successfully response", async () => {
+  describe("PurposeVersionActivated Event", () => {
+    it("save a new purpose for PurposeVersionActivated event should return a successfully response", async () => {
       const mockPurposeV1 = getMockPurpose() as PurposeV1;
       const mockPurposeVersionV1 = getMockPurposeVersion(
         PurposeStateV1.ACTIVE,

--- a/packages/purpose-event-consumer/test/messageHandlerV2.test.ts
+++ b/packages/purpose-event-consumer/test/messageHandlerV2.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from "vitest";
+import { createApiClient } from "pagopa-interop-tracing-operations-client";
+import {
+  OperationsService,
+  operationsServiceBuilder,
+} from "../src/services/operationsService.js";
+import { config } from "../src/utilities/config.js";
+import {
+  createAPurposeEventV2,
+  createAPurposeVersionEventV2,
+  createPurposeActivatedEventV2,
+  generateID,
+  getMockPurpose,
+  getMockPurposeVersion,
+} from "./utils.js";
+import { v4 as uuidv4 } from "uuid";
+import { AppContext, genericLogger } from "pagopa-interop-tracing-commons";
+import { kafkaMessageMissingData } from "pagopa-interop-tracing-models";
+import { handleMessageV2 } from "../src/handlers/messageHandlerV2.js";
+import { PurposeV2, PurposeVersionV2 } from "@pagopa/interop-outbound-models";
+import { errorInvalidVersion } from "../src/models/domain/errors.js";
+
+const apiClient = createApiClient(config.operationsBaseUrl);
+
+describe("Operations service test", () => {
+  const operationsService: OperationsService =
+    operationsServiceBuilder(apiClient);
+
+  const ctx: AppContext = {
+    serviceName: config.applicationName,
+    correlationId: uuidv4(),
+  };
+
+  describe("PurposeActivated Event", () => {
+    it("save a new purpose for PurposeActivated event should return a successfully response", async () => {
+      const mockPurposeV2 = {
+        ...getMockPurpose(),
+        isFreeOfCharge: false,
+      } as PurposeV2;
+      const mockPurposeVersionV2 = getMockPurposeVersion() as PurposeVersionV2;
+      const purpose: PurposeV2 = {
+        ...mockPurposeV2,
+        versions: [mockPurposeVersionV2],
+      };
+
+      const savePurposeSpy = vi
+        .spyOn(apiClient, "savePurpose")
+        .mockResolvedValueOnce(undefined);
+
+      const purposeV2Event = createPurposeActivatedEventV2(
+        purpose,
+        generateID(),
+      );
+
+      expect(
+        async () =>
+          await handleMessageV2(
+            purposeV2Event,
+            operationsService,
+            ctx,
+            genericLogger,
+          ),
+      ).not.toThrowError();
+
+      expect(savePurposeSpy).toBeCalled();
+    });
+
+    it("save a new purpose without data for PurposeActivated event should return an exception kafkaMessageMissingData", async () => {
+      const purposeV2Event = createPurposeActivatedEventV2(
+        undefined,
+        generateID(),
+      );
+
+      await expect(
+        handleMessageV2(purposeV2Event, operationsService, ctx, genericLogger),
+      ).rejects.toThrow(
+        kafkaMessageMissingData(config.kafkaTopic, purposeV2Event.type),
+      );
+    });
+
+    it("Should ignore these events: PurposeAdded, DraftPurposeUpdated, PurposeWaitingForApproval, DraftPurposeDeleted, WaitingForApprovalPurposeDeleted, NewPurposeVersionActivated, PurposeVersionActivated, PurposeVersionUnsuspendedByProducer, PurposeVersionUnsuspendedByConsumer, PurposeVersionSuspendedByProducer, PurposeVersionSuspendedByConsumer, NewPurposeVersionWaitingForApproval, PurposeVersionOverQuotaUnsuspended, PurposeArchived", async () => {
+      const mockPurposeV2 = getMockPurpose() as PurposeV2;
+      const mockPurposeVersionV2 = getMockPurposeVersion() as PurposeVersionV2;
+      const savePurposeSpy = vi
+        .spyOn(apiClient, "savePurpose")
+        .mockResolvedValueOnce(undefined);
+
+      const eventTypes = [
+        "PurposeAdded",
+        "DraftPurposeUpdated",
+        "PurposeWaitingForApproval",
+        "DraftPurposeDeleted",
+        "WaitingForApprovalPurposeDeleted",
+      ] as const;
+
+      const eventVersionTypes = [
+        "NewPurposeVersionActivated",
+        "PurposeVersionActivated",
+        "PurposeVersionUnsuspendedByProducer",
+        "PurposeVersionUnsuspendedByConsumer",
+        "PurposeVersionSuspendedByProducer",
+        "PurposeVersionSuspendedByConsumer",
+        "NewPurposeVersionWaitingForApproval",
+        "PurposeVersionOverQuotaUnsuspended",
+        "PurposeArchived",
+        "WaitingForApprovalPurposeVersionDeleted",
+        "PurposeVersionRejected",
+        "PurposeCloned",
+      ] as const;
+
+      const purpose: PurposeV2 = {
+        ...mockPurposeV2,
+        versions: [mockPurposeVersionV2],
+      };
+
+      for (const eventType of eventTypes) {
+        const purposeEventV2 = createAPurposeEventV2(eventType, purpose);
+        await handleMessageV2(
+          purposeEventV2,
+          operationsService,
+          ctx,
+          genericLogger,
+        );
+        expect(savePurposeSpy).not.toBeCalled();
+      }
+
+      for (const eventVersionType of eventVersionTypes) {
+        const purposeEventV2 = createAPurposeVersionEventV2(
+          eventVersionType,
+          purpose,
+        );
+        await handleMessageV2(
+          purposeEventV2,
+          operationsService,
+          ctx,
+          genericLogger,
+        );
+        expect(savePurposeSpy).not.toBeCalled();
+      }
+    });
+
+    it("Should throw errorInvalidVersion if versions has no valid state", async () => {
+      const mockPurposeV2 = getMockPurpose() as PurposeV2;
+      const purpose: PurposeV2 = {
+        ...mockPurposeV2,
+        versions: [],
+      };
+
+      const purposeV2Event = createPurposeActivatedEventV2(
+        purpose,
+        generateID(),
+      );
+
+      expect(
+        async () =>
+          await handleMessageV2(
+            purposeV2Event,
+            operationsService,
+            ctx,
+            genericLogger,
+          ),
+      ).rejects.toThrow(
+        errorInvalidVersion(
+          `Missing valid version within versions Array for purposeId ${purpose.id}`,
+        ),
+      );
+    });
+  });
+});

--- a/packages/purpose-event-consumer/test/tsconfig.json
+++ b/packages/purpose-event-consumer/test/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["."]
+}

--- a/packages/purpose-event-consumer/test/utils.ts
+++ b/packages/purpose-event-consumer/test/utils.ts
@@ -1,0 +1,38 @@
+import { AxiosError, AxiosRequestHeaders } from "axios";
+import { v4 as uuidv4 } from "uuid";
+
+import { PurposeV1, PurposeEventV1 } from "@pagopa/interop-outbound-models";
+
+export const generateID = (): string => uuidv4();
+
+export const createPurposeActivatedEventV1 = (
+  purposeV1: PurposeV1 | undefined,
+  stream_id?: string,
+  version?: number,
+): PurposeEventV1 => ({
+  type: "PurposeVersionActivated",
+  timestamp: new Date(),
+  event_version: 1,
+  version: version || 1,
+  stream_id: stream_id || generateID(),
+  data: {
+    purpose: purposeV1,
+  },
+});
+
+export function mockApiClientError(
+  status: number,
+  statusText: string,
+): AxiosError {
+  const mockAxiosError = new AxiosError(statusText);
+  mockAxiosError.response = {
+    status: status,
+    statusText: statusText,
+    headers: {},
+    config: {
+      headers: {} as AxiosRequestHeaders,
+    },
+    data: {},
+  };
+  return mockAxiosError;
+}

--- a/packages/purpose-event-consumer/test/utils.ts
+++ b/packages/purpose-event-consumer/test/utils.ts
@@ -1,10 +1,41 @@
 import { AxiosError, AxiosRequestHeaders } from "axios";
 import { v4 as uuidv4 } from "uuid";
 
-import { PurposeV1, PurposeEventV1 } from "@pagopa/interop-outbound-models";
+import {
+  PurposeV1,
+  PurposeEventV1,
+  PurposeStateV1,
+  PurposeStateV2,
+  PurposeV2,
+  PurposeVersionV1,
+  PurposeVersionV2,
+} from "@pagopa/interop-outbound-models";
+import { z } from "zod";
+import { match } from "ts-pattern";
 
+export const PurposeEventV1Type = z.union([
+  z.literal("PurposeCreated"),
+  z.literal("PurposeUpdated"),
+  z.literal("PurposeVersionWaitedForApproval"),
+  z.literal("PurposeVersionActivated"),
+  z.literal("PurposeVersionSuspended"),
+  z.literal("PurposeVersionArchived"),
+]);
+type PurposeEventV1Type = z.infer<typeof PurposeEventV1Type>;
+
+export const PurposeVersionEventV1Type = z.union([
+  z.literal("PurposeVersionCreated"),
+  z.literal("PurposeVersionActivated"),
+  z.literal("PurposeVersionUpdated"),
+  z.literal("PurposeVersionDeleted"),
+  z.literal("PurposeVersionRejected"),
+  z.literal("PurposeDeleted"),
+]);
+type PurposeVersionEventV1Type = z.infer<typeof PurposeVersionEventV1Type>;
 export const generateID = (): string => uuidv4();
-
+export function dateToBigInt(input: Date): bigint {
+  return BigInt(input.getTime());
+}
 export const createPurposeActivatedEventV1 = (
   purposeV1: PurposeV1 | undefined,
   stream_id?: string,
@@ -36,3 +67,119 @@ export function mockApiClientError(
   };
   return mockAxiosError;
 }
+
+export const createAPurposeEventV1 = (
+  type: PurposeEventV1Type,
+  purpose: PurposeV1,
+  stream_id?: string,
+  version?: number,
+): PurposeEventV1 => {
+  const purposeEventV1: PurposeEventV1 = {
+    type,
+    data: {
+      purpose,
+    },
+    event_version: 1,
+    stream_id: stream_id || generateID(),
+    version: version || 1,
+    timestamp: new Date(),
+  };
+  return purposeEventV1;
+};
+
+export const getMockPurpose = (
+  partialPurpose?: Partial<PurposeV1> | Partial<PurposeV2>,
+): PurposeV1 | PurposeV2 => ({
+  id: generateID(),
+  eserviceId: generateID(),
+  consumerId: generateID(),
+  versions: [],
+  title: "This is a Purpose for testing event consuming V1",
+  description: "This is a description for a test purpose",
+  createdAt: dateToBigInt(new Date()),
+  isFreeOfCharge: false,
+  ...partialPurpose,
+});
+
+export const getMockPurposeVersion = (
+  state?: PurposeStateV1 | PurposeStateV2,
+  partialPurposeVersion?: Partial<PurposeVersionV1> | Partial<PurposeVersionV2>,
+): PurposeVersionV1 | PurposeVersionV2 => ({
+  id: generateID(),
+  state: state || PurposeStateV1.DRAFT,
+  dailyCalls: 10,
+  createdAt: dateToBigInt(new Date()),
+  ...partialPurposeVersion,
+  ...(state !== PurposeStateV1.DRAFT
+    ? {
+        updatedAt: dateToBigInt(new Date()),
+        firstActivationAt: dateToBigInt(new Date()),
+      }
+    : {}),
+  ...(state === PurposeStateV1.SUSPENDED
+    ? { suspendedAt: dateToBigInt(new Date()) }
+    : {}),
+  ...(state === PurposeStateV1.REJECTED ? { rejectionReason: "test" } : {}),
+});
+
+export const createAPurposeVersionEventV1 = (
+  type: PurposeVersionEventV1Type,
+  purpose: PurposeV1,
+  stream_id?: string,
+  version?: number,
+): PurposeEventV1 => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const purposeGeneric: any = {
+    type,
+    event_version: 1,
+    stream_id: stream_id || generateID(),
+    version: version || 1,
+    timestamp: new Date(),
+  };
+  return (
+    match({ type })
+      .with({ type: "PurposeVersionRejected" }, () => ({
+        ...purposeGeneric,
+        data: {
+          purpose,
+          versionId: purpose.versions[0].id,
+        },
+      }))
+      .with({ type: "PurposeDeleted" }, () => ({
+        ...purposeGeneric,
+        data: {
+          purposeId: purpose.id,
+        },
+      }))
+      .with({ type: "PurposeVersionDeleted" }, () => ({
+        ...purposeGeneric,
+        data: {
+          purposeId: purpose.id,
+          versionId: purpose.versions[0].id,
+        },
+      }))
+      .with({ type: "PurposeVersionUpdated" }, () => ({
+        ...purposeGeneric,
+        data: {
+          purposeId: purpose.id,
+          version: purpose.versions[0],
+        },
+      }))
+      // eslint-disable-next-line sonarjs/no-identical-functions
+      .with({ type: "PurposeVersionCreated" }, () => ({
+        ...purposeGeneric,
+        data: {
+          purposeId: purpose.id,
+          version: purpose.versions[0],
+        },
+      }))
+      .with({ type: "PurposeVersionActivated" }, () => ({
+        ...purposeGeneric,
+        data: {
+          purposeId: purpose.id,
+          version: purpose.versions[0],
+        },
+      }))
+      .exhaustive()
+  );
+};

--- a/packages/purpose-event-consumer/test/utils.ts
+++ b/packages/purpose-event-consumer/test/utils.ts
@@ -136,50 +136,47 @@ export const createAPurposeVersionEventV1 = (
     version: version || 1,
     timestamp: new Date(),
   };
-  return (
-    match({ type })
-      .with({ type: "PurposeVersionRejected" }, () => ({
-        ...purposeGeneric,
-        data: {
-          purpose,
-          versionId: purpose.versions[0].id,
-        },
-      }))
-      .with({ type: "PurposeDeleted" }, () => ({
-        ...purposeGeneric,
-        data: {
-          purposeId: purpose.id,
-        },
-      }))
-      .with({ type: "PurposeVersionDeleted" }, () => ({
-        ...purposeGeneric,
-        data: {
-          purposeId: purpose.id,
-          versionId: purpose.versions[0].id,
-        },
-      }))
-      .with({ type: "PurposeVersionUpdated" }, () => ({
-        ...purposeGeneric,
-        data: {
-          purposeId: purpose.id,
-          version: purpose.versions[0],
-        },
-      }))
-      // eslint-disable-next-line sonarjs/no-identical-functions
-      .with({ type: "PurposeVersionCreated" }, () => ({
-        ...purposeGeneric,
-        data: {
-          purposeId: purpose.id,
-          version: purpose.versions[0],
-        },
-      }))
-      .with({ type: "PurposeVersionActivated" }, () => ({
-        ...purposeGeneric,
-        data: {
-          purposeId: purpose.id,
-          version: purpose.versions[0],
-        },
-      }))
-      .exhaustive()
-  );
+  return match({ type })
+    .with({ type: "PurposeVersionRejected" }, () => ({
+      ...purposeGeneric,
+      data: {
+        purpose,
+        versionId: purpose.versions[0].id,
+      },
+    }))
+    .with({ type: "PurposeDeleted" }, () => ({
+      ...purposeGeneric,
+      data: {
+        purposeId: purpose.id,
+      },
+    }))
+    .with({ type: "PurposeVersionDeleted" }, () => ({
+      ...purposeGeneric,
+      data: {
+        purposeId: purpose.id,
+        versionId: purpose.versions[0].id,
+      },
+    }))
+    .with({ type: "PurposeVersionUpdated" }, () => ({
+      ...purposeGeneric,
+      data: {
+        purposeId: purpose.id,
+        version: purpose.versions[0],
+      },
+    }))
+    .with({ type: "PurposeVersionCreated" }, () => ({
+      ...purposeGeneric,
+      data: {
+        purposeId: purpose.id,
+        version: purpose.versions[0],
+      },
+    }))
+    .with({ type: "PurposeVersionActivated" }, () => ({
+      ...purposeGeneric,
+      data: {
+        purposeId: purpose.id,
+        version: purpose.versions[0],
+      },
+    }))
+    .exhaustive();
 };

--- a/packages/purpose-event-consumer/test/vitest.config.ts
+++ b/packages/purpose-event-consumer/test/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+import { resolve } from "path";
+
+export default defineConfig({
+  root: ".",
+  test: {
+    clearMocks: true,
+    globals: true,
+    setupFiles: ["dotenv/config"],
+  },
+  resolve: {
+    alias: [{ find: "~", replacement: resolve(__dirname, "src") }],
+  },
+});

--- a/packages/purpose-event-consumer/tsconfig.check.json
+++ b/packages/purpose-event-consumer/tsconfig.check.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "test"]
+}

--- a/packages/purpose-event-consumer/tsconfig.json
+++ b/packages/purpose-event-consumer/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src", "test"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -685,6 +685,85 @@ importers:
         specifier: 0.33.0
         version: 0.33.0
 
+  packages/purpose-event-consumer:
+    dependencies:
+      '@pagopa/interop-outbound-models':
+        specifier: 1.0.3
+        version: 1.0.3
+      '@tsconfig/node-lts':
+        specifier: 20.1.0
+        version: 20.1.0
+      '@zodios/core':
+        specifier: 10.9.6
+        version: 10.9.6(axios@1.6.7)(zod@3.23.8)
+      axios:
+        specifier: 1.6.7
+        version: 1.6.7
+      dotenv-flow:
+        specifier: 3.3.0
+        version: 3.3.0
+      kafka-connector:
+        specifier: workspace:*
+        version: link:../kafka-connector
+      kafkajs:
+        specifier: 2.2.4
+        version: 2.2.4
+      pagopa-interop-tracing-commons:
+        specifier: workspace:*
+        version: link:../commons
+      pagopa-interop-tracing-models:
+        specifier: workspace:*
+        version: link:../models
+      pagopa-interop-tracing-operations-client:
+        specifier: workspace:*
+        version: link:../clients/operations
+      ts-pattern:
+        specifier: 5.2.0
+        version: 5.2.0
+      uuid:
+        specifier: 10.0.0
+        version: 10.0.0
+      zod:
+        specifier: 3.23.8
+        version: 3.23.8
+    devDependencies:
+      '@types/dotenv-flow':
+        specifier: 3.3.3
+        version: 3.3.3
+      '@types/node':
+        specifier: 20.3.1
+        version: 20.3.1
+      '@types/uuid':
+        specifier: 9.0.8
+        version: 9.0.8
+      '@typescript-eslint/eslint-plugin':
+        specifier: 6.21.0
+        version: 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.49.0)(typescript@5.5.2))(eslint@8.49.0)(typescript@5.5.2)
+      '@typescript-eslint/parser':
+        specifier: 6.21.0
+        version: 6.21.0(eslint@8.49.0)(typescript@5.5.2)
+      eslint:
+        specifier: 8.49.0
+        version: 8.49.0
+      eslint-config-prettier:
+        specifier: 9.0.0
+        version: 9.0.0(eslint@8.49.0)
+      eslint-plugin-prettier:
+        specifier: 5.0.0
+        version: 5.0.0(eslint-config-prettier@9.0.0(eslint@8.49.0))(eslint@8.49.0)(prettier@3.0.3)
+      prettier:
+        specifier: 3.0.3
+        version: 3.0.3
+      ts-node:
+        specifier: 10.9.2
+        version: 10.9.2(@types/node@20.3.1)(typescript@5.5.2)
+      typescript:
+        specifier: 5.5.2
+        version: 5.5.2
+      vitest:
+        specifier: 0.33.0
+        version: 0.33.0
+
   packages/state-updater:
     dependencies:
       '@tsconfig/node-lts':
@@ -1523,9 +1602,15 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@pagopa/interop-outbound-models@1.0.3':
+    resolution: {integrity: sha512-ENUWBjKnUIHKzchN7cvs2s/uS0yWW8suoUh+/Ziw+DJQus7jz89DCMa7PMhl6gLijGm8PM3QcNqyP2V6qm5/Eg==}
+
   '@pkgr/core@0.1.1':
     resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@protobuf-ts/runtime@2.9.4':
+    resolution: {integrity: sha512-vHRFWtJJB/SiogWDF0ypoKfRIZ41Kq+G9cEFj6Qm1eQaAhJ1LDFvgZ7Ja4tb3iLOQhz0PaoPnnOijF1qmEqTxg==}
 
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
@@ -3575,6 +3660,9 @@ packages:
 
   ts-pattern@5.1.2:
     resolution: {integrity: sha512-u+ElKUIWnqisjpRBhv6Y89yNq7Pmz6xL0v7pTSckrVZ0+5Vf32oh/3jmxWl80rAOGcnbBa7fCyeqNdP4yXzWWg==}
+
+  ts-pattern@5.2.0:
+    resolution: {integrity: sha512-aGaSpOlDcns7ZoeG/OMftWyQG1KqPVhgplhJxNCvyIXqWrumM5uIoOSarw/hmmi/T1PnuQ/uD8NaFHvLpHicDg==}
 
   ts-toolbelt@9.6.0:
     resolution: {integrity: sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==}
@@ -5647,7 +5735,15 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
 
+  '@pagopa/interop-outbound-models@1.0.3':
+    dependencies:
+      '@protobuf-ts/runtime': 2.9.4
+      ts-pattern: 5.2.0
+      zod: 3.23.8
+
   '@pkgr/core@0.1.1': {}
+
+  '@protobuf-ts/runtime@2.9.4': {}
 
   '@sinclair/typebox@0.27.8': {}
 
@@ -8120,6 +8216,8 @@ snapshots:
       yn: 3.1.1
 
   ts-pattern@5.1.2: {}
+
+  ts-pattern@5.2.0: {}
 
   ts-toolbelt@9.6.0: {}
 


### PR DESCRIPTION
###  Implemented `purpose-event-consumer` Microservice for Kafka Purposes events handling

Implemented two handlers (`messageHandlerV1` and `messageHandlerV2`) to process events for both v1 and v2:
- **messageHandlerV1**:  Handles `PurposeVersionActivated` event and ignores other events
- **messageHandlerV2**: Handles `PurposeActivated` event and ignores other events

Tests implemented for both versions, keeping them separated.
