### PR TITLE
PIN-5495: Missing data checker cron behaviour

### DIFF
--- a/packages/missing-data-checker/.env
+++ b/packages/missing-data-checker/.env
@@ -1,4 +1,4 @@
 APPLICATION_NAME="interop-tracing-missing-data-checker"
 API_OPERATIONS_BASEURL="http://localhost:3000"
 LOG_LEVEL="info"
-DAYS_OFFSET_FROM_TODAY=2
+DAYS_OFFSET_FROM_TODAY=1

--- a/packages/operations/src/services/db/dbService.ts
+++ b/packages/operations/src/services/db/dbService.ts
@@ -346,7 +346,7 @@ export function dbServiceBuilder(db: DB) {
             SELECT COUNT(*)
             FROM ${config.dbSchemaName}.tracings t3
             WHERE t3.tenant_id = t1.tenant_id
-          ) > 1;
+          ) > 0;
         `;
 
         const { total_count } = await db.one<{ total_count: number }>(
@@ -365,7 +365,7 @@ export function dbServiceBuilder(db: DB) {
             SELECT COUNT(*)
             FROM ${config.dbSchemaName}.tracings t3
             WHERE t3.tenant_id = t1.tenant_id
-          ) > 1
+          ) > 0
           OFFSET $1 LIMIT $2;
         `;
 


### PR DESCRIPTION
Adjusted `missing-data-checker` cron behavior to to use 1 day to avoid gaps between the first two submissions.

- Changed missing-data-checker to use a 1-day offset instead of 2 days to prevent missed MISSING entries.
- Updated query to check count > 0 for tracings

Needs to set the cron at the end of the day to make it work properly