### PR TITLE
PIN 5504: Date validation to prevent future dates in /tracings/submit

### DIFF
--- a/packages/api/src/routers/tracingRouter.ts
+++ b/packages/api/src/routers/tracingRouter.ts
@@ -10,6 +10,7 @@ import {
   correlationIdToHeader,
   genericError,
   organizationIdToHeader,
+  tracingFutureDate,
   tracingState,
 } from "pagopa-interop-tracing-models";
 import {
@@ -45,6 +46,14 @@ const tracingRouter =
           genericLogger.info(
             `Calling tracings submit with body: ${JSON.stringify(req.body)}`,
           );
+          const submissionDate = new Date(req.body.date);
+          const today = new Date();
+
+          if (submissionDate > today) {
+            throw tracingFutureDate(
+              `The submission date cannot be in the future.`,
+            );
+          }
           const result = await operationsService.submitTracing(
             {
               ...organizationIdToHeader(req.ctx.authData.organizationId),

--- a/packages/api/src/routers/tracingRouter.ts
+++ b/packages/api/src/routers/tracingRouter.ts
@@ -2,7 +2,6 @@ import { ZodiosEndpointDefinitions } from "@zodios/core";
 import { ZodiosRouter } from "@zodios/express";
 import {
   FileManager,
-  genericLogger,
   logger,
   zodiosValidationErrorToApiProblem,
 } from "pagopa-interop-tracing-commons";
@@ -10,7 +9,7 @@ import {
   correlationIdToHeader,
   genericError,
   organizationIdToHeader,
-  tracingFutureDate,
+  invalidTracingDate,
   tracingState,
 } from "pagopa-interop-tracing-models";
 import {
@@ -43,17 +42,15 @@ const tracingRouter =
     router
       .post("/tracings/submit", async (req, res) => {
         try {
-          genericLogger.info(
-            `Calling tracings submit with body: ${JSON.stringify(req.body)}`,
-          );
-          const submissionDate = new Date(req.body.date);
+          const tracingDate = new Date(req.body.date);
           const today = new Date();
 
-          if (submissionDate > today) {
-            throw tracingFutureDate(
-              `The submission date cannot be in the future.`,
+          if (tracingDate >= today) {
+            throw invalidTracingDate(
+              `The tracing date is invalid. Please provide a past date, earlier than today.`,
             );
           }
+
           const result = await operationsService.submitTracing(
             {
               ...organizationIdToHeader(req.ctx.authData.organizationId),

--- a/packages/api/src/routers/tracingRouter.ts
+++ b/packages/api/src/routers/tracingRouter.ts
@@ -42,8 +42,8 @@ const tracingRouter =
     router
       .post("/tracings/submit", async (req, res) => {
         try {
-          const tracingDate = new Date(req.body.date);
-          const today = new Date();
+          const tracingDate = new Date(req.body.date).toDateString();
+          const today = new Date().toDateString();
 
           if (tracingDate >= today) {
             throw invalidTracingDate(

--- a/packages/api/src/utilities/errorMapper.ts
+++ b/packages/api/src/utilities/errorMapper.ts
@@ -15,6 +15,7 @@ const {
 export const errorMapper = (error: ApiError<ErrorCodes>): number =>
   match(error.code)
     .with("tracingAlreadyExists", () => HTTP_STATUS_BAD_REQUEST)
+    .with("tracingFutureDate", () => HTTP_STATUS_BAD_REQUEST)
     .with("tracingNotFound", () => HTTP_STATUS_NOT_FOUND)
     .with("tracingCannotBeUpdated", () => HTTP_STATUS_CONFLICT)
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);

--- a/packages/api/src/utilities/errorMapper.ts
+++ b/packages/api/src/utilities/errorMapper.ts
@@ -15,7 +15,7 @@ const {
 export const errorMapper = (error: ApiError<ErrorCodes>): number =>
   match(error.code)
     .with("tracingAlreadyExists", () => HTTP_STATUS_BAD_REQUEST)
-    .with("tracingFutureDate", () => HTTP_STATUS_BAD_REQUEST)
+    .with("invalidTracingDate", () => HTTP_STATUS_BAD_REQUEST)
     .with("tracingNotFound", () => HTTP_STATUS_NOT_FOUND)
     .with("tracingCannotBeUpdated", () => HTTP_STATUS_CONFLICT)
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);

--- a/packages/api/test/router.test.ts
+++ b/packages/api/test/router.test.ts
@@ -18,7 +18,7 @@ import {
   tracingNotFound,
   tracingState,
   organizationIdToHeader,
-  tracingFutureDate,
+  invalidTracingDate,
 } from "pagopa-interop-tracing-models";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { config } from "../src/utilities/config.js";
@@ -208,7 +208,8 @@ describe("Tracing Router", () => {
       expect(response.text).contains(errorMessage);
       expect(response.status).toBe(400);
     });
-    it("should return a 400 status bad request error if a tracing date is in the future", async () => {
+
+    it("should return a 400 Bad Request error if the provided tracing date is not a past date", async () => {
       const mockFile = Buffer.from("test file content");
       const mockSubmitTracingResponse: ApiSubmitTracingResponse = {
         tracingId: generateId(),
@@ -218,9 +219,9 @@ describe("Tracing Router", () => {
         errors: false,
       };
 
-      const errorMessage = `The submission date cannot be in the future.`;
+      const errorMessage = `The tracing date is invalid. Please provide a past date, earlier than today.`;
       const apiErrorMock = makeApiProblem(
-        tracingFutureDate(errorMessage),
+        invalidTracingDate(errorMessage),
         errorMapper,
         genericLogger,
       );

--- a/packages/api/test/router.test.ts
+++ b/packages/api/test/router.test.ts
@@ -207,6 +207,41 @@ describe("Tracing Router", () => {
       expect(response.text).contains(errorMessage);
       expect(response.status).toBe(400);
     });
+    it("should return a 400 status bad request error if a tracing date is in the future", async () => {
+      const mockFile = Buffer.from("test file content");
+      const mockSubmitTracingResponse: ApiSubmitTracingResponse = {
+        tracingId: generateId(),
+        tenantId: generateId(),
+        date: new Date(Date.now() + 86400000).toISOString().split("T")[0],
+        version: 1,
+        errors: false,
+      };
+
+      const errorMessage = `The submission date cannot be in the future.`;
+      const apiErrorMock = makeApiProblem(
+        tracingAlreadyExists(errorMessage),
+        errorMapper,
+        genericLogger,
+      );
+
+      const operationsApiClientError =
+        mockOperationsApiClientError(apiErrorMock);
+
+      vi.spyOn(operationsApiClient, "submitTracing").mockRejectedValue(
+        operationsApiClientError,
+      );
+
+      const originalFilename: string = "testfile.txt";
+      const response = await tracingApiClient
+        .post("/tracings/submit")
+        .attach("file", mockFile, originalFilename)
+        .field("date", mockSubmitTracingResponse.date)
+        .set("Authorization", `Bearer test-token`)
+        .set("Content-Type", "multipart/form-data");
+
+      expect(response.text).contains(errorMessage);
+      expect(response.status).toBe(400);
+    });
   });
 
   describe("getTracings", () => {

--- a/packages/api/test/router.test.ts
+++ b/packages/api/test/router.test.ts
@@ -18,6 +18,7 @@ import {
   tracingNotFound,
   tracingState,
   organizationIdToHeader,
+  tracingFutureDate,
 } from "pagopa-interop-tracing-models";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { config } from "../src/utilities/config.js";
@@ -219,7 +220,7 @@ describe("Tracing Router", () => {
 
       const errorMessage = `The submission date cannot be in the future.`;
       const apiErrorMock = makeApiProblem(
-        tracingAlreadyExists(errorMessage),
+        tracingFutureDate(errorMessage),
         errorMapper,
         genericLogger,
       );

--- a/packages/models/src/errors.ts
+++ b/packages/models/src/errors.ts
@@ -119,7 +119,7 @@ const errorCodes = {
   tracingAlreadyExists: "TRACING_ALREADY_EXISTS",
   tracingNotFound: "TRACING_NOT_FOUND",
   tracingCannotBeUpdated: "TRACING_CANNOT_BE_UPDATED",
-  tracingFutureDate: "TRACING_FUTURE_DATE",
+  invalidTracingDate: "INVALID_TRACING_DATE",
   kafkaMessageProcessError: "KAFKA_MESSAGE_PROCESS_ERROR",
   kafkaMessageValueError: "KAFKA_MESSAGE_VALUE_ERROR",
   kafkaMessageMissingData: "KAFKA_MESSAGE_MISSING_DATA",
@@ -267,10 +267,12 @@ export function tracingAlreadyExists(
     title: "Bad Request",
   });
 }
-export function tracingFutureDate(details: string): ApiError<CommonErrorCodes> {
+export function invalidTracingDate(
+  details: string,
+): ApiError<CommonErrorCodes> {
   return new ApiError({
     detail: details,
-    code: "tracingFutureDate",
+    code: "invalidTracingDate",
     title: "Bad Request",
   });
 }

--- a/packages/models/src/errors.ts
+++ b/packages/models/src/errors.ts
@@ -119,6 +119,7 @@ const errorCodes = {
   tracingAlreadyExists: "TRACING_ALREADY_EXISTS",
   tracingNotFound: "TRACING_NOT_FOUND",
   tracingCannotBeUpdated: "TRACING_CANNOT_BE_UPDATED",
+  tracingFutureDate: "TRACING_FUTURE_DATE",
   kafkaMessageProcessError: "KAFKA_MESSAGE_PROCESS_ERROR",
   kafkaMessageValueError: "KAFKA_MESSAGE_VALUE_ERROR",
   kafkaMessageMissingData: "KAFKA_MESSAGE_MISSING_DATA",
@@ -263,6 +264,13 @@ export function tracingAlreadyExists(
   return new ApiError({
     detail: details,
     code: "tracingAlreadyExists",
+    title: "Bad Request",
+  });
+}
+export function tracingFutureDate(details: string): ApiError<CommonErrorCodes> {
+  return new ApiError({
+    detail: details,
+    code: "tracingFutureDate",
     title: "Bad Request",
   });
 }


### PR DESCRIPTION
- date validation in the /tracings/submit endpoint to prevent submissions with future dates.
- tests