### PR TITLE
Delegations-consumer: added info log

### DIFF
--- a/packages/delegation-event-consumer/src/handlers/messageHandlerV2.ts
+++ b/packages/delegation-event-consumer/src/handlers/messageHandlerV2.ts
@@ -47,6 +47,10 @@ export async function handleMessageV2(
             },
             logger,
           );
+        } else {
+          logger.info(
+            `Skip event: Delegation kind - ${delegation.kind} - is not relevant`,
+          );
         }
       },
     )


### PR DESCRIPTION
Added skip event log when delegation `kind` is not `DELEGATED_CONSUMER`