### PR TITLE
Outbound models version upgrade (1.2.0)

### DIFF
--- a/packages/delegation-event-consumer/package.json
+++ b/packages/delegation-event-consumer/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@pagopa/interop-outbound-models": "1.0.11-f",
+    "@pagopa/interop-outbound-models": "1.2.0",
     "@zodios/core": "10.9.6",
     "dotenv-flow": "3.3.0",
     "kafka-connector": "workspace:*",

--- a/packages/eservice-event-consumer/package.json
+++ b/packages/eservice-event-consumer/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@pagopa/interop-outbound-models": "1.0.11-f",
+    "@pagopa/interop-outbound-models": "1.2.0",
     "@tsconfig/node-lts": "20.1.0",
     "@zodios/core": "10.9.6",
     "axios": "1.6.7",

--- a/packages/eservice-event-consumer/src/handlers/messageHandlerV2.ts
+++ b/packages/eservice-event-consumer/src/handlers/messageHandlerV2.ts
@@ -21,6 +21,7 @@ export async function handleMessageV2(
           "EServiceAdded",
           "EServiceCloned",
           "EServiceDescriptionUpdated",
+          "EServiceNameUpdated",
         ),
       },
       async (evt) => {

--- a/packages/kafka-producer/package.json
+++ b/packages/kafka-producer/package.json
@@ -23,7 +23,7 @@
     "zod": "3.23.8"
   },
   "devDependencies": {
-    "@pagopa/interop-outbound-models": "1.0.11-f",
+    "@pagopa/interop-outbound-models": "1.2.0",
     "@types/express": "4.17.17",
     "@types/node": "20.3.1",
     "ts-node": "10.9.2",

--- a/packages/purpose-event-consumer/package.json
+++ b/packages/purpose-event-consumer/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@pagopa/interop-outbound-models": "1.0.11-f",
+    "@pagopa/interop-outbound-models": "1.2.0",
     "@zodios/core": "10.9.6",
     "dotenv-flow": "3.3.0",
     "kafka-connector": "workspace:*",

--- a/packages/tenant-event-consumer/package.json
+++ b/packages/tenant-event-consumer/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@pagopa/interop-outbound-models": "1.0.11-f",
+    "@pagopa/interop-outbound-models": "1.2.0",
     "@zodios/core": "10.9.6",
     "dotenv-flow": "3.3.0",
     "kafka-connector": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -331,8 +331,8 @@ importers:
   packages/delegation-event-consumer:
     dependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.0.11-f
-        version: 1.0.11-f
+        specifier: 1.2.0
+        version: 1.2.0
       '@tsconfig/node-lts':
         specifier: 20.1.0
         version: 20.1.0
@@ -480,8 +480,8 @@ importers:
   packages/eservice-event-consumer:
     dependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.0.11-f
-        version: 1.0.11-f
+        specifier: 1.2.0
+        version: 1.2.0
       '@tsconfig/node-lts':
         specifier: 20.1.0
         version: 20.1.0
@@ -603,8 +603,8 @@ importers:
         version: 3.23.8
     devDependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.0.11-f
-        version: 1.0.11-f
+        specifier: 1.2.0
+        version: 1.2.0
       '@types/express':
         specifier: 4.17.17
         version: 4.17.17
@@ -929,8 +929,8 @@ importers:
   packages/purpose-event-consumer:
     dependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.0.11-f
-        version: 1.0.11-f
+        specifier: 1.2.0
+        version: 1.2.0
       '@tsconfig/node-lts':
         specifier: 20.1.0
         version: 20.1.0
@@ -1078,8 +1078,8 @@ importers:
   packages/tenant-event-consumer:
     dependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.0.11-f
-        version: 1.0.11-f
+        specifier: 1.2.0
+        version: 1.2.0
       '@tsconfig/node-lts':
         specifier: 20.1.0
         version: 20.1.0
@@ -1914,8 +1914,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@pagopa/interop-outbound-models@1.0.11-f':
-    resolution: {integrity: sha512-zgDL6/UyWhm15LTm/n3dF8y74JgccQZj8uaQXIdONxdWEbXIBtgr8Z9Rtk1iAVUYeB6ZyF+53z01oquGfYI/dw==}
+  '@pagopa/interop-outbound-models@1.2.0':
+    resolution: {integrity: sha512-hg5W1+OXknBnCcIGSs0VJEPfCidABvQ1AmmVudvUSwgG4lNmxBXSyw8hSFl4Ejryl/h8wKxPgSg5sUvkabnh4w==}
 
   '@pkgr/core@0.1.1':
     resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
@@ -6034,7 +6034,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
 
-  '@pagopa/interop-outbound-models@1.0.11-f':
+  '@pagopa/interop-outbound-models@1.2.0':
     dependencies:
       '@protobuf-ts/runtime': 2.9.4
       ts-pattern: 5.2.0


### PR DESCRIPTION
This PR updates `interop-outbound-models` package to version `1.2.0`

- `EserviceNameUpdated` event handling impemented