### PR TITLE
Update interop-outbound-model to 1.3.2

### DIFF
--- a/packages/delegation-event-consumer/package.json
+++ b/packages/delegation-event-consumer/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@pagopa/interop-outbound-models": "1.2.0",
+    "@pagopa/interop-outbound-models": "1.3.2",
     "@zodios/core": "10.9.6",
     "dotenv-flow": "3.3.0",
     "kafka-connector": "workspace:*",

--- a/packages/delegation-event-consumer/src/handlers/messageHandlerV2.ts
+++ b/packages/delegation-event-consumer/src/handlers/messageHandlerV2.ts
@@ -59,7 +59,13 @@ export async function handleMessageV2(
 
     .with(
       {
-        type: P.union("ProducerDelegationRejected"),
+        type: P.union(
+          "ProducerDelegationRejected",
+          "ConsumerDelegationSubmitted",
+          "ConsumerDelegationApproved",
+          "ConsumerDelegationRejected",
+          "ConsumerDelegationRevoked",
+        ),
       },
       async (evt) => {
         logger.info(`Skip event ${evt.type} (not relevant)`);

--- a/packages/eservice-event-consumer/package.json
+++ b/packages/eservice-event-consumer/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@pagopa/interop-outbound-models": "1.2.0",
+    "@pagopa/interop-outbound-models": "1.3.2",
     "@tsconfig/node-lts": "20.1.0",
     "@zodios/core": "10.9.6",
     "axios": "1.6.7",

--- a/packages/eservice-event-consumer/src/handlers/messageHandlerV2.ts
+++ b/packages/eservice-event-consumer/src/handlers/messageHandlerV2.ts
@@ -80,6 +80,10 @@ export async function handleMessageV2(
           "EServiceDescriptorSubmittedByDelegate",
           "EServiceDescriptorApprovedByDelegator",
           "EServiceDescriptorRejectedByDelegator",
+          "EServiceIsDelegableEnabled",
+          "EServiceIsDelegableDisabled",
+          "EServiceIsClientAccessDelegableEnabled",
+          "EServiceIsClientAccessDelegableDisabled",
         ),
       },
       async (evt) => {

--- a/packages/kafka-producer/package.json
+++ b/packages/kafka-producer/package.json
@@ -23,7 +23,7 @@
     "zod": "3.23.8"
   },
   "devDependencies": {
-    "@pagopa/interop-outbound-models": "1.2.0",
+    "@pagopa/interop-outbound-models": "1.3.2",
     "@types/express": "4.17.17",
     "@types/node": "20.3.1",
     "ts-node": "10.9.2",

--- a/packages/purpose-event-consumer/package.json
+++ b/packages/purpose-event-consumer/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@pagopa/interop-outbound-models": "1.2.0",
+    "@pagopa/interop-outbound-models": "1.3.2",
     "@zodios/core": "10.9.6",
     "dotenv-flow": "3.3.0",
     "kafka-connector": "workspace:*",

--- a/packages/tenant-event-consumer/package.json
+++ b/packages/tenant-event-consumer/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@pagopa/interop-outbound-models": "1.2.0",
+    "@pagopa/interop-outbound-models": "1.3.2",
     "@zodios/core": "10.9.6",
     "dotenv-flow": "3.3.0",
     "kafka-connector": "workspace:*",

--- a/packages/tenant-event-consumer/src/handlers/messageHandlerV2.ts
+++ b/packages/tenant-event-consumer/src/handlers/messageHandlerV2.ts
@@ -72,6 +72,8 @@ export async function handleMessageV2(
           "TenantDelegatedProducerFeatureAdded",
           "TenantDelegatedProducerFeatureRemoved",
           "TenantCertifiedAttributeAssigned",
+          "TenantDelegatedConsumerFeatureAdded",
+          "TenantDelegatedConsumerFeatureRemoved",
         ),
       },
       async (evt) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -331,8 +331,8 @@ importers:
   packages/delegation-event-consumer:
     dependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.2.0
-        version: 1.2.0
+        specifier: 1.3.2
+        version: 1.3.2
       '@tsconfig/node-lts':
         specifier: 20.1.0
         version: 20.1.0
@@ -480,8 +480,8 @@ importers:
   packages/eservice-event-consumer:
     dependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.2.0
-        version: 1.2.0
+        specifier: 1.3.2
+        version: 1.3.2
       '@tsconfig/node-lts':
         specifier: 20.1.0
         version: 20.1.0
@@ -603,8 +603,8 @@ importers:
         version: 3.23.8
     devDependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.2.0
-        version: 1.2.0
+        specifier: 1.3.2
+        version: 1.3.2
       '@types/express':
         specifier: 4.17.17
         version: 4.17.17
@@ -929,8 +929,8 @@ importers:
   packages/purpose-event-consumer:
     dependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.2.0
-        version: 1.2.0
+        specifier: 1.3.2
+        version: 1.3.2
       '@tsconfig/node-lts':
         specifier: 20.1.0
         version: 20.1.0
@@ -1078,8 +1078,8 @@ importers:
   packages/tenant-event-consumer:
     dependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.2.0
-        version: 1.2.0
+        specifier: 1.3.2
+        version: 1.3.2
       '@tsconfig/node-lts':
         specifier: 20.1.0
         version: 20.1.0
@@ -1914,8 +1914,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@pagopa/interop-outbound-models@1.2.0':
-    resolution: {integrity: sha512-hg5W1+OXknBnCcIGSs0VJEPfCidABvQ1AmmVudvUSwgG4lNmxBXSyw8hSFl4Ejryl/h8wKxPgSg5sUvkabnh4w==}
+  '@pagopa/interop-outbound-models@1.3.2':
+    resolution: {integrity: sha512-ecV6q5POBUQyh/VKmCUsVzpk9XXhqdrILldCTrmwN0sND65M4prSubo/t/E66urBTP9HYzsHpvRMdMQVu2JpTw==}
 
   '@pkgr/core@0.1.1':
     resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
@@ -6034,7 +6034,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
 
-  '@pagopa/interop-outbound-models@1.2.0':
+  '@pagopa/interop-outbound-models@1.3.2':
     dependencies:
       '@protobuf-ts/runtime': 2.9.4
       ts-pattern: 5.2.0


### PR DESCRIPTION

#### Added Events for eServices
- `EServiceIsDelegableEnabled`
- `EServiceIsDelegableDisabled`
- `EServiceIsClientAccessDelegableEnabled`
- `EServiceIsClientAccessDelegableDisabled`

*These events are skipped as they are not related to eService table updates.*

#### Added Events for Delegations
- `ConsumerDelegationSubmitted`
- `ConsumerDelegationApproved`
- `ConsumerDelegationRejected`
- `ConsumerDelegationRevoked`

*These events are skipped as they do not impact the producer.*

#### Added Events for Tenants
- `TenantDelegatedConsumerFeatureAdded`
- `TenantDelegatedConsumerFeatureRemoved`

*These events are also skipped.*

