### PR TITLE
PIN-6390: Skip processing not relevant events on SQS queue

### DIFF
--- a/packages/commons/src/sqs/messageValidation.ts
+++ b/packages/commons/src/sqs/messageValidation.ts
@@ -2,9 +2,18 @@ import { sqsMessageNotValid } from "pagopa-interop-tracing-models";
 import { Message } from "./sqs.js";
 import { genericLogger } from "../index.js";
 
-type WhitelistedEvent = "ObjectCreated";
+type WhitelistedEvent =
+  | "ObjectCreated"
+  | "ObjectCreated:Put"
+  | "ObjectCreated:Post"
+  | "ObjectCreated:Copy";
 
-const validEvents: WhitelistedEvent[] = ["ObjectCreated"];
+const validEvents: WhitelistedEvent[] = [
+  "ObjectCreated",
+  "ObjectCreated:Put",
+  "ObjectCreated:Post",
+  "ObjectCreated:Copy",
+];
 
 type EventValidation = "ValidEvent" | "InvalidEvent";
 
@@ -25,7 +34,7 @@ export const validateSqsMessage = (message: Message): EventValidation => {
       const record = body.Records[0];
       const eventName = record?.eventName;
 
-      if (eventName && validEvents.some((ev) => eventName.includes(ev))) {
+      if (eventName && validEvents.includes(eventName)) {
         return "ValidEvent";
       } else {
         genericLogger.warn(`Skipping event - ${eventName}`);

--- a/packages/commons/src/sqs/messageValidation.ts
+++ b/packages/commons/src/sqs/messageValidation.ts
@@ -25,7 +25,7 @@ export const validateSqsMessage = (message: Message): EventValidation => {
       const record = body.Records[0];
       const eventName = record?.eventName;
 
-      if (eventName && validEvents.includes(eventName)) {
+      if (eventName && validEvents.some((ev) => eventName.includes(ev))) {
         return "ValidEvent";
       } else {
         genericLogger.warn(`Skipping event - ${eventName}`);

--- a/packages/commons/src/sqs/messageValidation.ts
+++ b/packages/commons/src/sqs/messageValidation.ts
@@ -1,0 +1,38 @@
+import { sqsMessageNotValid } from "pagopa-interop-tracing-models";
+import { Message } from "./sqs.js";
+import { genericLogger } from "../index.js";
+
+type WhitelistedEvent = "ObjectCreated";
+
+const validEvents: WhitelistedEvent[] = ["ObjectCreated"];
+
+type EventValidation = "ValidEvent" | "InvalidEvent";
+
+export const validateSqsMessage = (message: Message): EventValidation => {
+  if (!message.Body) {
+    throw new Error("Message body is undefined");
+  }
+
+  try {
+    const body = JSON.parse(message.Body);
+
+    if (body.Event === "s3:TestEvent") {
+      genericLogger.info(`s3:TestEvent detected`);
+      return "InvalidEvent";
+    }
+
+    if (Array.isArray(body.Records)) {
+      const record = body.Records[0];
+      const eventName = record?.eventName;
+
+      if (eventName && validEvents.includes(eventName)) {
+        return "ValidEvent";
+      } else {
+        genericLogger.warn(`Skipping event - ${eventName}`);
+      }
+    }
+    return "InvalidEvent";
+  } catch (error) {
+    throw sqsMessageNotValid(`${error}`);
+  }
+};

--- a/packages/commons/src/sqs/messageValidation.ts
+++ b/packages/commons/src/sqs/messageValidation.ts
@@ -17,7 +17,7 @@ export const validateSqsMessage = (message: Message): EventValidation => {
     const body = JSON.parse(message.Body);
 
     if (body.Event === "s3:TestEvent") {
-      genericLogger.info(`s3:TestEvent detected`);
+      genericLogger.warn(`Skipping event - ${body.Event}`);
       return "InvalidEvent";
     }
 

--- a/packages/commons/src/sqs/sqs.ts
+++ b/packages/commons/src/sqs/sqs.ts
@@ -10,6 +10,8 @@ import {
 import { genericLogger, logger } from "../logging/index.js";
 import { ConsumerConfig } from "../config/consumerConfig.js";
 import { InternalError } from "pagopa-interop-tracing-models";
+import { match } from "ts-pattern";
+import { validateSqsMessage } from "./messageValidation.js";
 
 const serializeError = (error: unknown): string => {
   try {
@@ -52,19 +54,26 @@ const processQueue = async (
 
     if (Messages?.length) {
       for (const message of Messages) {
-        if (!message.ReceiptHandle) {
-          throw new Error(
-            `ReceiptHandle not found in Message: ${JSON.stringify(message)}`,
-          );
-        }
-
         try {
-          await consumerHandler(message);
-          await deleteMessage(
-            sqsClient,
-            config.queueUrl,
-            message.ReceiptHandle,
-          );
+          const result = validateSqsMessage(message);
+          if (!message.ReceiptHandle) {
+            throw new Error(
+              `ReceiptHandle not found in Message: ${JSON.stringify(message)}`,
+            );
+          }
+          const receiptHandle = message.ReceiptHandle;
+
+          await match(result)
+            .with("InvalidEvent", async () => {
+              genericLogger.info(`Deleting message - invalid event detected.`);
+              await deleteMessage(sqsClient, config.queueUrl, receiptHandle);
+            })
+            .with("ValidEvent", async () => {
+              genericLogger.info("Processing valid event.");
+              await consumerHandler(message);
+              await deleteMessage(sqsClient, config.queueUrl, receiptHandle);
+            })
+            .exhaustive();
         } catch (e) {
           genericLogger.error(
             `Unexpected error consuming message: ${JSON.stringify(

--- a/packages/commons/src/sqs/sqs.ts
+++ b/packages/commons/src/sqs/sqs.ts
@@ -65,11 +65,9 @@ const processQueue = async (
 
           await match(result)
             .with("InvalidEvent", async () => {
-              genericLogger.info(`Deleting message - invalid event detected.`);
               await deleteMessage(sqsClient, config.queueUrl, receiptHandle);
             })
             .with("ValidEvent", async () => {
-              genericLogger.info("Processing valid event.");
               await consumerHandler(message);
               await deleteMessage(sqsClient, config.queueUrl, receiptHandle);
             })

--- a/packages/minio-webhook/src/index.ts
+++ b/packages/minio-webhook/src/index.ts
@@ -6,7 +6,10 @@ import { genericLogger } from "pagopa-interop-tracing-commons";
 const app = express();
 app.use(express.json());
 
-const normalizeEventData = (eventData: any): any => {
+const normalizeEventData = (eventData: {
+  EventName: string;
+  Records: { eventName: string }[];
+}) => {
   if (!eventData) return eventData;
 
   if (eventData.EventName?.startsWith("s3:")) {

--- a/packages/minio-webhook/src/index.ts
+++ b/packages/minio-webhook/src/index.ts
@@ -6,6 +6,27 @@ import { genericLogger } from "pagopa-interop-tracing-commons";
 const app = express();
 app.use(express.json());
 
+const normalizeEventData = (eventData: any): any => {
+  if (!eventData) return eventData;
+
+  if (eventData.EventName?.startsWith("s3:")) {
+    eventData.EventName = eventData.EventName.slice(3);
+  }
+
+  if (Array.isArray(eventData.Records)) {
+    eventData.Records = eventData.Records.map(
+      (record: { eventName: string }) => ({
+        ...record,
+        eventName: record.eventName?.startsWith("s3:")
+          ? record.eventName.slice(3)
+          : record.eventName,
+      }),
+    );
+  }
+
+  return eventData;
+};
+
 app.post("/webhook/:queue", async (req: Request, res: Response) => {
   try {
     genericLogger.info(
@@ -15,9 +36,10 @@ app.post("/webhook/:queue", async (req: Request, res: Response) => {
     );
 
     const queueUrl = `${config.elasticMQ}/${req.params.queue}`;
+    const normalizedEvent = normalizeEventData(req.body);
     const body = new URLSearchParams({
       Action: "SendMessage",
-      MessageBody: JSON.stringify(req.body),
+      MessageBody: JSON.stringify(normalizedEvent),
     });
     const response = await axios.post(queueUrl, body.toString(), {
       headers: { "Content-Type": "application/x-www-form-urlencoded" },

--- a/packages/models/src/errors.ts
+++ b/packages/models/src/errors.ts
@@ -124,6 +124,7 @@ const errorCodes = {
   kafkaMessageProcessError: "KAFKA_MESSAGE_PROCESS_ERROR",
   kafkaMessageValueError: "KAFKA_MESSAGE_VALUE_ERROR",
   kafkaMessageMissingData: "KAFKA_MESSAGE_MISSING_DATA",
+  sqsMessageNotValid: "SQS_MESSAGE_NOT_VALID",
 } as const;
 
 export type CommonErrorCodes = keyof typeof errorCodes;
@@ -151,6 +152,15 @@ export function genericInternalError(
 ): InternalError<CommonErrorCodes> {
   return new InternalError({
     code: "genericError",
+    detail: details,
+  });
+}
+
+export function sqsMessageNotValid(
+  details: string,
+): InternalError<CommonErrorCodes> {
+  return new InternalError({
+    code: "sqsMessageNotValid",
     detail: details,
   });
 }


### PR DESCRIPTION
This PR checks SQS events by validating them against a whitelist.

- Skips `s3:TestEvent` entirely.
- For s3EventNotification, only `ObjectCreated:*` events are considered valid.