### PR TITLE
OpenAPI spec: align error code format

### DIFF
--- a/packages/api/open-api/api-external-interop-v1.yaml
+++ b/packages/api/open-api/api-external-interop-v1.yaml
@@ -445,16 +445,11 @@ components:
       properties:
         code:
           description: Internal code of the error
-          example: 123-4567
-          minLength: 8
-          maxLength: 8
-          pattern: "^[0-9]{3}-[0-9]{4}$"
+          example: TRACING_ALREADY_EXISTS
           type: string
         detail:
           description: A human readable explanation specific to this occurrence of the problem.
           example: Parameter not valid
-          maxLength: 4096
-          pattern: "^.{0,1024}$"
           type: string
       required:
         - code


### PR DESCRIPTION
- Updated `ProblemError.code` field:
  - Removed outdated `pattern`, `minLength`, `maxLength`
  - Updated `example` from numeric (`123-4567`) to symbolic (`TRACING_ALREADY_EXISTS`)
  - Updated description from "Internal code of the error" to `Internal error code`
