### PR TITLE
PIN-9364: allow S3 CompleteMultipartUpload event

### DIFF
--- a/packages/commons/src/sqs/messageValidation.ts
+++ b/packages/commons/src/sqs/messageValidation.ts
@@ -6,13 +6,15 @@ type WhitelistedEvent =
   | "ObjectCreated"
   | "ObjectCreated:Put"
   | "ObjectCreated:Post"
-  | "ObjectCreated:Copy";
+  | "ObjectCreated:Copy"
+  | "ObjectCreated:CompleteMultipartUpload";
 
 const validEvents: WhitelistedEvent[] = [
   "ObjectCreated",
   "ObjectCreated:Put",
   "ObjectCreated:Post",
   "ObjectCreated:Copy",
+  "ObjectCreated:CompleteMultipartUpload",
 ];
 
 type EventValidation = "ValidEvent" | "InvalidEvent";


### PR DESCRIPTION
## Jira Issue
[PIN-9364](https://pagopa.atlassian.net/browse/PIN-9364)

## Services Impacted
- commons

## Key Changes
- Added event: `ObjectCreated:CompleteMultipartUpload`.

## Traceability Checklist
- [x] Branch name contain the Jira key

[PIN-9364]: https://pagopa.atlassian.net/browse/PIN-9364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ