### PR TITLE
prevent ERR_STREAM_PREMATURE_CLOSE when stopping CSV parsing

### DIFF
--- a/packages/commons/src/utils/csvHandler.ts
+++ b/packages/commons/src/utils/csvHandler.ts
@@ -1,6 +1,5 @@
 import csv from "csv-parser";
 import { Readable } from "stream";
-
 export async function parseCSV<T>(
   stream: Readable,
   onChunk: (rows: T[], stopProcessing: () => void) => Promise<void>,
@@ -13,7 +12,6 @@ export async function parseCSV<T>(
 
   const stopProcessing = () => {
     isProcessStopped = true;
-    parser.destroy();
   };
 
   try {
@@ -24,6 +22,7 @@ export async function parseCSV<T>(
 
       if (chunk.length >= CHUNK_SIZE) {
         await onChunk(chunk, stopProcessing);
+        if (isProcessStopped) break;
         chunk = [];
       }
     }
@@ -32,7 +31,8 @@ export async function parseCSV<T>(
       await onChunk(chunk, stopProcessing);
     }
   } catch (err) {
-    parser.destroy();
     throw err;
+  } finally {
+    parser.destroy();
   }
 }

--- a/packages/commons/src/utils/csvHandler.ts
+++ b/packages/commons/src/utils/csvHandler.ts
@@ -30,8 +30,6 @@ export async function parseCSV<T>(
     if (!isProcessStopped && chunk.length > 0) {
       await onChunk(chunk, stopProcessing);
     }
-  } catch (err) {
-    throw err;
   } finally {
     parser.destroy();
   }


### PR DESCRIPTION
Calling `parser.destroy()` inside the `stopProcessing` callback caused a `ERR_STREAM_PREMATURE_CLOSE` error because it forcefully killed the stream while the for await loop was still active.

- Updated `stopProcessing` to only set a termination flag.
- Modified the loop to break when the flag is set.
- Moved `parser.destroy()` to a `finally` block to ensure resources are cleaned up only after the loop exits.