### PR TITLE
PIN-9457: update traces merge command

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,6 @@
 version: "3"
 name: pagopa-interop-tracing
 services:
-  
   postgres:
     volumes:
       - ../packages/operations/test/init-db.sql:/docker-entrypoint-initdb.d/01-init.sql

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,19 +2,6 @@ version: "3"
 name: pagopa-interop-tracing
 services:
   
-  postgres-15:
-    volumes:
-      - ../packages/operations/test/init-db.sql:/docker-entrypoint-initdb.d/01-init.sql
-      - ../packages/enriched-data-handler/test/init-db.sql:/docker-entrypoint-initdb.d/02-init.sql
-    image: postgres:15
-    ports:
-      - 55001:5432
-    environment:
-      POSTGRES_DB: tracing_db
-      POSTGRES_USER: mydbuser
-      POSTGRES_PASSWORD: mypassword
-    command: -c 'max_connections=512' -c 'wal_level=logical'
-
   postgres:
     volumes:
       - ../packages/operations/test/init-db.sql:/docker-entrypoint-initdb.d/01-init.sql

--- a/packages/commons/src/utils/csvHandler.ts
+++ b/packages/commons/src/utils/csvHandler.ts
@@ -1,5 +1,6 @@
 import csv from "csv-parser";
 import { Readable } from "stream";
+
 export async function parseCSV<T>(
   stream: Readable,
   onChunk: (rows: T[], stopProcessing: () => void) => Promise<void>,

--- a/packages/enriched-data-handler/src/repositories/traces.repository.ts
+++ b/packages/enriched-data-handler/src/repositories/traces.repository.ts
@@ -45,7 +45,6 @@ export function tracesRepository(db: DBContext) {
       const mergeQuery = generateMergeQuery(
         TracingEnrichedSchema,
         config.dbSchemaName,
-        ["tracingId"],
         targetTableName,
       );
       await tx.none(mergeQuery);

--- a/packages/enriched-data-handler/src/utilities/sqlQueryHelper.ts
+++ b/packages/enriched-data-handler/src/utilities/sqlQueryHelper.ts
@@ -4,53 +4,30 @@ import { ColumnSet, IColumnDescriptor, IMain, ITask } from "pg-promise";
 import { config } from "./config.js";
 
 /**
- * Generates a MERGE SQL query for efficient upsert operations.
- * This query handles both inserting new records and updating existing ones
- * based on a specified ON condition.
+ * Generates an INSERT query that inserts new records from a staging table
+ * into the target table.
  *
- * @template T - The Zod object schema shape defining the table structure.
- * @param tableSchema - A Zod object schema representing the structure of the data.
- * @param schemaName - The database schema name where the target table resides.
- * @param tableName - The name of the target table for the MERGE operation.
- * @param keysOn - An array of column keys used in the ON condition to identify matching rows.
- * @returns The generated MERGE SQL query string.
+ * @param tableSchema - A Zod object schema refering to the table model from which to extract the list of keys.
+ * @param schemaName - The target db schema name.
+ * @param tableName - The staging and target table name.
  */
 export function generateMergeQuery<T extends z.ZodRawShape>(
   tableSchema: z.ZodObject<T>,
   schemaName: string,
-  keysOn: Array<keyof T>,
   tableName: string,
 ): string {
   const keys = Object.keys(tableSchema.shape);
+
   const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
+  const targetTableName = `${schemaName}.${tableName}`;
 
-  const updateSet = keys
-    .map((k) => `${toSnakeCase(String(k))} = source.${toSnakeCase(String(k))}`)
-    .join(",\n    ");
-
-  const columns = keys.map((k) => toSnakeCase(String(k))).join(", ");
-  const values = keys.map((k) => `source.${toSnakeCase(String(k))}`).join(", ");
-
-  const onCondition = keysOn
-    .map(
-      (key) =>
-        `${schemaName}.${tableName}.${toSnakeCase(
-          String(key),
-        )} = source.${toSnakeCase(String(key))}`,
-    )
-    .join(" AND ");
+  const columnList = keys.map((k) => toSnakeCase(String(k))).join(", ");
 
   return `
-        MERGE INTO ${schemaName}.${tableName}
-        USING ${stagingTableName} AS source
-        ON ${onCondition}
-        WHEN MATCHED THEN
-          UPDATE SET
-            ${updateSet}
-        WHEN NOT MATCHED THEN
-          INSERT (${columns})
-          VALUES (${values});
-      `;
+    INSERT INTO ${targetTableName} (${columnList})
+    SELECT ${keys.map((k) => `s.${toSnakeCase(String(k))}`).join(", ")}
+    FROM ${stagingTableName} s;
+`;
 }
 
 export type ColumnValue = string | number | Date | undefined | null | boolean;

--- a/packages/enriched-data-handler/test/config.ts
+++ b/packages/enriched-data-handler/test/config.ts
@@ -3,7 +3,7 @@ import { resolve } from "path";
 import { GenericContainer } from "testcontainers";
 
 export const TEST_POSTGRES_DB_PORT = 5432;
-export const TEST_POSTGRES_DB_IMAGE = "postgres:15";
+export const TEST_POSTGRES_DB_IMAGE = "postgres:14";
 
 export const postgreSQLContainer = (config: DbConfig): GenericContainer => {
   return new GenericContainer(TEST_POSTGRES_DB_IMAGE)

--- a/packages/enriched-data-handler/test/init-db.sql
+++ b/packages/enriched-data-handler/test/init-db.sql
@@ -11,3 +11,6 @@ CREATE TABLE tracing.traces (
     requests_count INTEGER,
     created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
 );
+
+-- PostgreSQL only
+CREATE INDEX IF NOT EXISTS idx_tracing_traces_tracing_id ON tracing.traces (tracing_id);

--- a/packages/enriched-data-handler/test/init-db.sql
+++ b/packages/enriched-data-handler/test/init-db.sql
@@ -11,6 +11,3 @@ CREATE TABLE tracing.traces (
     requests_count INTEGER,
     created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
 );
-
--- PostgreSQL only
-CREATE INDEX IF NOT EXISTS idx_tracing_traces_tracing_id ON tracing.traces (tracing_id);


### PR DESCRIPTION
## Jira Issue
[PIN-9457](https://pagopa.atlassian.net/browse/PIN-9457)

## Context/Why
- Remove dependency on `MERGE` for PostgreSQL and Redshift full compatibility.

## Services Impacted
- enriched-data-handler
- operations

## Key Changes
- Simplified `generateMergeQuery` to `INSERT INTO ... SELECT ...` for Traces.
- Removed Postgres 15 from compose and set test image to Postgres 14.

## Traceability Checklist
- [x] Branch name contain the Jira key
- [x] PR title is compliant with the standard
- [x] API and integration tests updated

[PIN-9457]: https://pagopa.atlassian.net/browse/PIN-9457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ