### PR TITLE
fix: add defaults to staging table creation

### DIFF
--- a/packages/enriched-data-handler/src/utilities/setupDbService.ts
+++ b/packages/enriched-data-handler/src/utilities/setupDbService.ts
@@ -8,7 +8,7 @@ export function setupDbServiceBuilder(conn: DBConnection) {
         tableNames.map((tableName) => {
           const query = `
                 CREATE TEMPORARY TABLE IF NOT EXISTS ${tableName}_${config.mergeTableSuffix} (
-                  LIKE ${config.dbSchemaName}.${tableName}
+                  LIKE ${config.dbSchemaName}.${tableName} INCLUDING DEFAULTS
                 );
               `;
           return conn.query(query);

--- a/packages/enriched-data-handler/test/init-db.sql
+++ b/packages/enriched-data-handler/test/init-db.sql
@@ -9,5 +9,5 @@ CREATE TABLE tracing.traces (
     token_id VARCHAR(36),
     status INTEGER,
     requests_count INTEGER,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
 );

--- a/packages/enriched-data-handler/test/init-db.sql
+++ b/packages/enriched-data-handler/test/init-db.sql
@@ -9,5 +9,5 @@ CREATE TABLE tracing.traces (
     token_id VARCHAR(36),
     status INTEGER,
     requests_count INTEGER,
-    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
 );


### PR DESCRIPTION
## Context / Why
The staging temp table created with LIKE does not inherit default values. Since created_at is NOT NULL, inserts into staging fail because the default isn’t applied. We now include defaults when creating the staging table to prevent this error.

## Services Impacted
- enriched-data-handler

## Key Changes
- Added default to staging tables setup
- Aligned traces db sql to migration

## Traceability Checklist
- [ ] Branch name contain the Jira key