### PR TITLE
PIN-9335: Replace internal tracing state ERROR with FAILED and preserve external API compatibility

### DIFF
--- a/packages/api/src/routers/tracingRouter.ts
+++ b/packages/api/src/routers/tracingRouter.ts
@@ -26,6 +26,10 @@ import {
 import storage from "../routers/config/multer.js";
 import { LocalExpressContext, LocalZodiosContext } from "../context/index.js";
 import { readExpressMulterFile } from "../utilities/fileData.js";
+import {
+  mapExternalGetTracingsQueryToInternal,
+  mapInternalTracingsToExternal,
+} from "../utilities/tracingStateMapper.js";
 
 const tracingRouter =
   (
@@ -117,12 +121,14 @@ const tracingRouter =
       })
       .get("/tracings", async (req, res) => {
         try {
+          const mappedQuery = mapExternalGetTracingsQueryToInternal(req.query);
+
           const data = await operationsService.getTracings(
             {
               ...organizationIdToHeader(req.ctx.authData.organizationId),
               ...correlationIdToHeader(req.ctx.correlationId),
             },
-            req.query,
+            mappedQuery,
           );
           const result = ApiTracingsContent.safeParse(data);
           if (!result.success) {
@@ -135,10 +141,14 @@ const tracingRouter =
             throw genericError("Unable to parse tracings items");
           }
 
+          const mappedResults = mapInternalTracingsToExternal(
+            result.data.results,
+          );
+
           return res
             .status(200)
             .json({
-              results: result.data.results,
+              results: mappedResults,
               totalCount: result.data.totalCount,
             })
             .end();

--- a/packages/api/src/utilities/tracingStateMapper.ts
+++ b/packages/api/src/utilities/tracingStateMapper.ts
@@ -1,0 +1,35 @@
+import { ApiGetTracingsQuery } from "pagopa-interop-tracing-operations-client";
+import { tracingState } from "pagopa-interop-tracing-models";
+import { ApiExternalGetTracingsQuery } from "../model/types.js";
+
+export const externalTracingState = {
+  error: "ERROR",
+} as const;
+
+export function mapExternalTracingStateToInternal(state: string): string {
+  return state === externalTracingState.error ? tracingState.error : state;
+}
+
+export function mapInternalTracingStateToExternal(state: string): string {
+  return state === tracingState.error ? externalTracingState.error : state;
+}
+
+export function mapExternalGetTracingsQueryToInternal(
+  query: ApiExternalGetTracingsQuery,
+): ApiGetTracingsQuery {
+  return {
+    ...query,
+    states: query.states?.map(mapExternalTracingStateToInternal) as
+      | ApiGetTracingsQuery["states"]
+      | undefined,
+  };
+}
+
+export function mapInternalTracingsToExternal<T extends { state: string }>(
+  results: T[],
+): T[] {
+  return results.map((tracing) => ({
+    ...tracing,
+    state: mapInternalTracingStateToExternal(tracing.state),
+  }));
+}

--- a/packages/api/test/router.test.ts
+++ b/packages/api/test/router.test.ts
@@ -55,6 +55,7 @@ import {
 } from "../src/model/types.js";
 import { configureMulterEndpoints } from "../src/routers/config/multer.js";
 import { LocalExpressContext, localZodiosCtx } from "../src/context/index.js";
+import { externalTracingState } from "../src/utilities/tracingStateMapper.js";
 
 const operationsApiClient = createApiClient(config.operationsBaseUrl);
 const operationsService: OperationsService =
@@ -252,7 +253,7 @@ describe("Tracing Router", () => {
   describe("getTracings", () => {
     it("retrieve non-empty list of tracings", async () => {
       const searchQuery: ApiExternalGetTracingsQuery = {
-        states: [tracingState.error, tracingState.pending],
+        states: [externalTracingState.error, tracingState.pending],
         offset: 0,
         limit: 10,
       };
@@ -283,6 +284,18 @@ describe("Tracing Router", () => {
         .query(searchQuery);
 
       expect(response.status).toBe(200);
+      expect(response.body.results[0].state).toBe(externalTracingState.error);
+      expect(operationsApiClient.getTracings).toHaveBeenCalledWith({
+        queries: {
+          states: [tracingState.error, tracingState.pending],
+          offset: searchQuery.offset,
+          limit: searchQuery.limit,
+        },
+        headers: {
+          ...correlationIdToHeader(mockAppCtx.correlationId),
+          ...organizationIdToHeader(mockAppCtx.authData.organizationId),
+        },
+      });
     });
 
     it("retrieve empty list of tracings", async () => {
@@ -482,7 +495,7 @@ describe("Tracing Router", () => {
       );
     });
 
-    it("should return a 409 status error if the tracing to update does not have a state ERROR or MISSING", async () => {
+    it("should return a 409 status error if the tracing to update does not have a state FAILED or MISSING", async () => {
       const mockFile = Buffer.from("test file content");
       const mockRecoverTracingResponse: ApiRecoverTracingResponse = {
         tracingId: generateId(),
@@ -524,7 +537,7 @@ describe("Tracing Router", () => {
         tenantId: generateId(),
         date: "2024-06-11",
         version: 2,
-        previousState: "ERROR",
+        previousState: "FAILED",
       };
 
       const apiErrorMock = makeApiProblem(
@@ -559,7 +572,7 @@ describe("Tracing Router", () => {
         tenantId: generateId(),
         date: "2024-06-11",
         version: 2,
-        previousState: "ERROR",
+        previousState: "FAILED",
       };
 
       const bucketS3Key = buildS3Key(
@@ -632,7 +645,7 @@ describe("Tracing Router", () => {
         tenantId: generateId(),
         date: "2024-06-11",
         version: 2,
-        previousState: "ERROR",
+        previousState: "FAILED",
       };
 
       const bucketS3Key = buildS3Key(
@@ -806,7 +819,7 @@ describe("Tracing Router", () => {
         tenantId: generateId(),
         date: "2024-06-11",
         version: 2,
-        previousState: "ERROR",
+        previousState: "FAILED",
       };
 
       const apiErrorMock = makeApiProblem(
@@ -841,7 +854,7 @@ describe("Tracing Router", () => {
         tenantId: generateId(),
         date: "2024-06-11",
         version: 2,
-        previousState: "ERROR",
+        previousState: "FAILED",
       };
 
       const bucketS3Key = buildS3Key(
@@ -912,7 +925,7 @@ describe("Tracing Router", () => {
         tenantId: generateId(),
         date: "2024-06-11",
         version: 2,
-        previousState: "ERROR",
+        previousState: "FAILED",
       };
 
       const bucketS3Key = buildS3Key(

--- a/packages/models/src/errors.ts
+++ b/packages/models/src/errors.ts
@@ -291,7 +291,7 @@ export function tracingRecoverCannotBeUpdated(
   tracingId: string,
 ): ApiError<CommonErrorCodes> {
   return new ApiError({
-    detail: `Tracing with Id ${tracingId} cannot be updated. The state of tracing must be either ERROR or MISSING.`,
+    detail: `Tracing with Id ${tracingId} cannot be updated. The state of tracing must be either FAILED or MISSING.`,
     code: "tracingCannotBeUpdated",
     title: "Tracing cannot be updated",
   });

--- a/packages/models/src/tracing/tracing.ts
+++ b/packages/models/src/tracing/tracing.ts
@@ -3,7 +3,7 @@ import z from "zod";
 export const tracingState = {
   pending: "PENDING",
   missing: "MISSING",
-  error: "ERROR",
+  error: "FAILED",
   completed: "COMPLETED",
 } as const;
 export const TracingState = z.enum([

--- a/packages/operations/open-api/api-tracing-operations-interop-v1.yaml
+++ b/packages/operations/open-api/api-tracing-operations-interop-v1.yaml
@@ -819,7 +819,7 @@ components:
         - PENDING
         - COMPLETED
         - MISSING
-        - ERROR
+        - FAILED
 
     SubmitTracingRequest:
       type: object

--- a/packages/operations/src/services/db/dbService.ts
+++ b/packages/operations/src/services/db/dbService.ts
@@ -145,7 +145,7 @@ export function dbServiceBuilder(db: DB) {
         const findPastTracingErrorsQuery = `
           SELECT 1 
           FROM ${config.dbSchemaName}.tracings tracing
-          WHERE (tracing.state = 'ERROR' OR tracing.state = 'MISSING')
+          WHERE (tracing.state = 'FAILED' OR tracing.state = 'MISSING')
             AND tracing.tenant_id = $1
             AND tracing.id <> $2
           LIMIT 1`;

--- a/packages/operations/test/operationsService.test.ts
+++ b/packages/operations/test/operationsService.test.ts
@@ -286,7 +286,7 @@ describe("database test", () => {
     });
 
     describe("getTracings", () => {
-      it("searching with 'states' parameter 'ERROR' should return an empty list of tracings", async () => {
+      it("searching with 'states' parameter 'FAILED' should return an empty list of tracings", async () => {
         const filters: ApiGetTracingsQuery & { tenantId: string } = {
           states: [tracingState.error],
           offset: 0,
@@ -314,7 +314,7 @@ describe("database test", () => {
         expect(result.totalCount).toBe(0);
       });
 
-      it("searching with 'states' parameter 'ERROR' should return only 1 record with 'ERROR' state", async () => {
+      it("searching with 'states' parameter 'FAILED' should return only 1 record with 'FAILED' state", async () => {
         const filters: ApiGetTracingsQuery & { tenantId: string } = {
           states: [tracingState.error],
           offset: 0,
@@ -353,7 +353,7 @@ describe("database test", () => {
         expect(result.results[0].state).toBe(tracingState.error);
       });
 
-      it("searching with 'states' parameter 'ERROR' & 'MISSING' should return 2 records with both states", async () => {
+      it("searching with 'states' parameter 'FAILED' & 'MISSING' should return 2 records with both states", async () => {
         const filters: ApiGetTracingsQuery & { tenantId: string } = {
           states: [tracingState.error, tracingState.missing],
           offset: 0,
@@ -652,7 +652,7 @@ describe("database test", () => {
     });
 
     describe("updateTracingState", () => {
-      it("should update a tracing by tracingId with new state 'ERROR' successfully", async () => {
+      it("should update a tracing by tracingId with new state 'FAILED' successfully", async () => {
         const tracingData: Tracing = {
           id: generateId<TracingId>(),
           tenant_id: tenantId,
@@ -722,7 +722,7 @@ describe("database test", () => {
     });
 
     describe("recoverTracing", () => {
-      it("should update an existing tracing from state 'ERROR/MISSING' to state 'PENDING' and new version successfully", async () => {
+      it("should update an existing tracing from state 'FAILED/MISSING' to state 'PENDING' and new version successfully", async () => {
         const tracingData: Tracing = {
           id: generateId<TracingId>(),
           tenant_id: tenantId,
@@ -1149,7 +1149,7 @@ describe("database test", () => {
     });
 
     describe("deletePurposesErrors", () => {
-      it("should delete purposes errors with version below the related tracing version with state ERROR, and return 1 record with version 3", async () => {
+      it("should delete purposes errors with version below the related tracing version with state FAILED, and return 1 record with version 3", async () => {
         const tracingData: Tracing = {
           id: generateId<TracingId>(),
           tenant_id: tenantId,

--- a/packages/state-updater/test/consumerProcessingError.test.ts
+++ b/packages/state-updater/test/consumerProcessingError.test.ts
@@ -25,7 +25,7 @@ describe("Consumer processing result queue test", () => {
     vi.restoreAllMocks();
   });
 
-  it("given valid ERROR message, method should call updateTracingState and copyPurposeErrorsFromS3", async () => {
+  it("given valid FAILED message, method should call updateTracingState and copyPurposeErrorsFromS3", async () => {
     const validMessage: SQS.Message = {
       MessageId: "12345",
       ReceiptHandle: "receipt_handle_id",
@@ -47,7 +47,7 @@ describe("Consumer processing result queue test", () => {
     );
   });
 
-  it("given valid ERROR message with stale version, should not copy or update", async () => {
+  it("given valid FAILED message with stale version, should not copy or update", async () => {
     mockTracingStoreService.checkTracingVersion.mockResolvedValueOnce(false);
 
     const validMessage: SQS.Message = {


### PR DESCRIPTION
[PIN-9335](https://pagopa.atlassian.net/browse/PIN-9335)

### Summary
This PR replaces the internal tracing state `ERROR` with `FAILED` across the tracing domain and operations flow.

To preserve backward compatibility for external consumers, the external API contract is unchanged: `GET /tracings` still accepts/returns `ERROR`.

### What Changed

- Replaced internal state usage from `ERROR` to `FAILED` in models and business logic.
- Updated operations-side OpenAPI enum from `ERROR` to `FAILED`.
- Updated SQL logic that explicitly checked `ERROR` to now check `FAILED`.
- Updated error messages and test expectations accordingly.
- Added a dedicated API mapping layer for compatibility:
  - Input mapping (external -> internal): `ERROR` -> `FAILED`
  - Output mapping (internal -> external): `FAILED` -> `ERROR`

### Backward Compatibility
- External API consumers are unaffected.
- `GET /tracings` continues to expose `ERROR` as agreed with integrators.
- The compatibility behavior is centralized in a dedicated mapper module to avoid scattered hardcoded conversions.

### Notes
- This change introduces an internal/external state separation by design:
  - Internal domain state: `FAILED`
  - External API compatibility state: `ERROR`

[PIN-9335]: https://pagopa.atlassian.net/browse/PIN-9335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ