### PR TITLE
chore(PIN-9570): align env config naming state-updater like processing

### DIFF
--- a/packages/state-updater/.env
+++ b/packages/state-updater/.env
@@ -3,7 +3,7 @@ LOG_LEVEL=info
 
 AWS_REGION="eu-central-1"
 SQS_ENDPOINT="http://localhost:9324"
-SQS_ENDPOINT_PROCESSING_RESULTS_QUEUE="http://localhost:9324/000000000000/processing-results"
+SQS_PROCESSING_RESULTS_ENDPOINT="http://localhost:9324/000000000000/processing-results"
 CONSUMER_POLLING_TIMEOUT_IN_SECONDS="3"
 
 AWS_CONFIG_FILE=aws.config.local

--- a/packages/state-updater/src/index.ts
+++ b/packages/state-updater/src/index.ts
@@ -52,7 +52,7 @@ const sqsClient: SQS.SQSClient = await SQS.instantiateClient({
 await SQS.runConsumer(
   sqsClient,
   {
-    queueUrl: config.sqsEndpointProcessingResultsQueue,
+    queueUrl: config.sqsProcessingResultsEndpoint,
     maxNumberOfMessages: config.maxNumberOfMessages,
     waitTimeSeconds: config.waitTimeSeconds,
     visibilityTimeout: config.visibilityTimeout,

--- a/packages/state-updater/src/utilities/config.ts
+++ b/packages/state-updater/src/utilities/config.ts
@@ -15,7 +15,7 @@ const tracingStateUpdateronfig = AWSConfig.and(ConsumerConfig)
     z
       .object({
         APPLICATION_NAME: z.string(),
-        SQS_ENDPOINT_PROCESSING_RESULTS_QUEUE: z.string(),
+        SQS_PROCESSING_RESULTS_ENDPOINT: z.string(),
         SQS_ENDPOINT: z.string().nullish(),
         S3_TRACING_ERRORS_BUCKET_NAME: z.string(),
         AWS_ACCESS_KEY_ID: z.string().nullish(),
@@ -24,8 +24,7 @@ const tracingStateUpdateronfig = AWSConfig.and(ConsumerConfig)
       })
       .transform((c) => ({
         applicationName: c.APPLICATION_NAME,
-        sqsEndpointProcessingResultsQueue:
-          c.SQS_ENDPOINT_PROCESSING_RESULTS_QUEUE,
+        sqsProcessingResultsEndpoint: c.SQS_PROCESSING_RESULTS_ENDPOINT,
         sqsEndpoint: c.SQS_ENDPOINT,
         bucketTracingErrorsS3Name: c.S3_TRACING_ERRORS_BUCKET_NAME,
         awsAccessKeyId: c.AWS_ACCESS_KEY_ID,


### PR DESCRIPTION
## Jira Issue
[PIN-9570](https://pagopa.atlassian.net/browse/PIN-9570)

## Context/Why
- Align env config naming to processing in state-updater
- Rename SQS processing results endpoint var for consistency

## Services Impacted
- state-updater

## Key Changes
- Rename env var `SQS_ENDPOINT_PROCESSING_RESULTS_QUEUE` to `SQS_PROCESSING_RESULTS_ENDPOINT`
- Update config mapping and usage in `state-updater`

## Traceability Checklist
- [x] Branch name contain the Jira key
- [x] PR title is compliant with the standard


[PIN-9570]: https://pagopa.atlassian.net/browse/PIN-9570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ