### PR TITLE
fix(PIN-9710): reject invalid x-correlation-id header

### DIFF
--- a/packages/commons/src/context/context.ts
+++ b/packages/commons/src/context/context.ts
@@ -7,7 +7,9 @@ import { logger, Logger } from "../logging/index.js";
 import { readCorrelationIdHeader } from "./headers.js";
 import {
   CorrelationId,
+  badRequestError,
   generateId,
+  makeApiProblemBuilder,
   unsafeBrandId,
 } from "pagopa-interop-tracing-models";
 import { v4 as uuidv4 } from "uuid";
@@ -36,14 +38,32 @@ export const contextMiddleware =
     serviceName: string,
     overrideCorrelationId: boolean = false,
   ): ZodiosRouterContextRequestHandler<ExpressContext> =>
-  (req, _res, next): void => {
+  (req, res, next): void => {
+    const headerCorrelationId = readCorrelationIdHeader(req);
+    const parsedCorrelationId = headerCorrelationId
+      ? CorrelationId.safeParse(headerCorrelationId)
+      : null;
+
+    if (headerCorrelationId && !parsedCorrelationId?.success) {
+      const correlationId = generateId<CorrelationId>();
+      const makeApiProblem = makeApiProblemBuilder({});
+      const problem = makeApiProblem(
+        badRequestError("Invalid x-correlation-id header"),
+        () => 400,
+        logger({ serviceName, correlationId }),
+        correlationId,
+      );
+      res.status(problem.status).json(problem).end();
+      return;
+    }
+
     req.ctx = {
       serviceName,
       correlationId: overrideCorrelationId
         ? generateId<CorrelationId>()
-        : unsafeBrandId<CorrelationId>(
-            readCorrelationIdHeader(req) || uuidv4(),
-          ),
+        : parsedCorrelationId?.success
+        ? parsedCorrelationId.data
+        : unsafeBrandId<CorrelationId>(uuidv4()),
     } as AppContext;
 
     next();


### PR DESCRIPTION
## Jira Issue
[PIN-9710](https://pagopa.atlassian.net/browse/PIN-9710)

## Context/Why
- `x-correlation-id` is used to build S3 keys but was not validated at runtime
- Invalid values could break S3 key parsing or pollute logs
- Add runtime UUID `x-correlation-id` validation and return `400` if the header is invalid

## Services Impacted
- commons (context middleware)

## Key Changes
- Validate `x-correlation-id` with `CorrelationId.safeParse`
- Return `400` when the header is invalid
- Keep existing behavior when the header is absent (generate new UUID)

## Traceability Checklist
- [x] Branch name contain the Jira key
- [x] PR title is compliant with the standard (type(scope): descrizione (KEY))


[PIN-9710]: https://pagopa.atlassian.net/browse/PIN-9710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ