### PR TITLE
fix(PIN-9710): return x-correlation-id in response

### DIFF
--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -74,7 +74,7 @@ app.use(helmet.frameguard({ action: "deny" }));
 app.use(healthRouter);
 app.use(queryParamsMiddleware);
 app.use(express.urlencoded({ extended: true }));
-app.use(contextMiddleware(config.applicationName));
+app.use(contextMiddleware(config.applicationName, true));
 app.use(loggerMiddleware(config.applicationName));
 app.use(authenticationMiddleware);
 

--- a/packages/commons/src/context/context.ts
+++ b/packages/commons/src/context/context.ts
@@ -36,15 +36,18 @@ export const contextMiddleware =
     serviceName: string,
     overrideCorrelationId: boolean = false,
   ): ZodiosRouterContextRequestHandler<ExpressContext> =>
-  (req, _res, next): void => {
+  (req, res, next): void => {
+    const correlationId = overrideCorrelationId
+      ? generateId<CorrelationId>()
+      : unsafeBrandId<CorrelationId>(
+          readCorrelationIdHeader(req) || uuidv4(),
+        );
+
     req.ctx = {
       serviceName,
-      correlationId: overrideCorrelationId
-        ? generateId<CorrelationId>()
-        : unsafeBrandId<CorrelationId>(
-            readCorrelationIdHeader(req) || uuidv4(),
-          ),
+      correlationId,
     } as AppContext;
 
+    res.header("X-Correlation-Id", req.ctx.correlationId);
     next();
   };

--- a/packages/commons/src/context/context.ts
+++ b/packages/commons/src/context/context.ts
@@ -39,9 +39,7 @@ export const contextMiddleware =
   (req, res, next): void => {
     const correlationId = overrideCorrelationId
       ? generateId<CorrelationId>()
-      : unsafeBrandId<CorrelationId>(
-          readCorrelationIdHeader(req) || uuidv4(),
-        );
+      : unsafeBrandId<CorrelationId>(readCorrelationIdHeader(req) || uuidv4());
 
     req.ctx = {
       serviceName,


### PR DESCRIPTION
## Jira Issue
[PIN-9710](https://pagopa.atlassian.net/browse/PIN-9710)

## Context/Why
- Returning `x-correlation-id` in response headers
- CorrelationId should be internal and not controlled by clients

## Services Impacted
- commons
- api

## Key Changes
- Always set `X-Correlation-Id` response header in `contextMiddleware`
- API ignores any incoming `x-correlation-id` by enabling `overrideCorrelationId`

## Traceability Checklist
- [x] Branch name contain the Jira key
- [x] PR title is compliant with the standard


[PIN-9710]: https://pagopa.atlassian.net/browse/PIN-9710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ