### PR TITLE
feature(PIN-9742): add severity to errors spec and filter

### DIFF
--- a/packages/api/open-api/api-external-interop-v1.yaml
+++ b/packages/api/open-api/api-external-interop-v1.yaml
@@ -96,6 +96,14 @@ paths:
             format: int32
             minimum: 1
             maximum: 50
+        - in: query
+          name: severity
+          required: false
+          schema:
+            type: string
+            enum:
+              - INVALID
+              - WARNING
       responses:
         "200":
           description: Successful response
@@ -356,6 +364,11 @@ components:
             properties:
               purposeId:
                 type: string
+              severity:
+                type: string
+                enum:
+                  - INVALID
+                  - WARNING
               errorCode:
                 type: string
               message:
@@ -366,6 +379,7 @@ components:
                 minimum: 0
             required:
               - purposeId
+              - severity
               - errorCode
               - message
               - rowNumber
@@ -400,6 +414,7 @@ components:
         - COMPLETED
         - MISSING
         - ERROR
+        - WARNING
     Problem:
       properties:
         type:

--- a/packages/operations/open-api/api-tracing-operations-interop-v1.yaml
+++ b/packages/operations/open-api/api-tracing-operations-interop-v1.yaml
@@ -389,6 +389,14 @@ paths:
             format: int32
             minimum: 1
             maximum: 50
+        - in: query
+          name: severity
+          required: false
+          schema:
+            type: string
+            enum:
+              - INVALID
+              - WARNING
       responses:
         "200":
           description: Successful response

--- a/packages/operations/src/services/db/dbService.ts
+++ b/packages/operations/src/services/db/dbService.ts
@@ -80,20 +80,22 @@ export function dbServiceBuilder(db: DB) {
       offset: number;
       limit: number;
       tracing_id: string;
+      severity?: string;
     }): Promise<{ results: PurposeError[]; totalCount: number }> {
       try {
-        const { offset, limit, tracing_id } = filters;
+        const { offset, limit, tracing_id, severity } = filters;
 
         const getTracingErrorsTotalCountQuery = `
           SELECT COUNT(*)::integer as total_count
           FROM ${config.dbSchemaName}.purposes_errors pe 
             JOIN ${config.dbSchemaName}.tracings tr ON tr.id = pe.tracing_id
           WHERE tr.version = pe.version AND pe.tracing_id = $1
+            AND ($2::text IS NULL OR pe.severity = $2)
         `;
 
         const { total_count } = await db.one<{ total_count: number }>(
           getTracingErrorsTotalCountQuery,
-          [tracing_id],
+          [tracing_id, severity ?? null],
         );
 
         const getTracingErrorsQuery = `
@@ -101,13 +103,14 @@ export function dbServiceBuilder(db: DB) {
           FROM ${config.dbSchemaName}.purposes_errors pe 
             JOIN ${config.dbSchemaName}.tracings tr ON tr.id = pe.tracing_id
           WHERE tr.version = pe.version AND pe.tracing_id = $3
+            AND ($4::text IS NULL OR pe.severity = $4)
           ORDER BY pe.row_number
           OFFSET $1 LIMIT $2
         `;
 
         const tracingErrors = await db.any<PurposeError>(
           getTracingErrorsQuery,
-          [offset, limit, tracing_id],
+          [offset, limit, tracing_id, severity ?? null],
         );
 
         return {


### PR DESCRIPTION
## Jira Issue
[PIN-9742](https://pagopa.atlassian.net/browse/PIN-9742)

## Context/Why
- The errors endpoint did not expose `severity`, so clients couldn’t distinguish WARNING from INVALID.
- Add `severity` to the API specs and introduce an optional filter to query only WARNING/INVALID errors.

## Services Impacted
- operations
- api

## Key Changes
 - Add `severity` field to tracing errors response in OpenAPI specs
 - Add optional `severity` query param to `/tracings/{tracingId}/errors`
 - Apply severity filter in operations DB query

## Traceability Checklist
- [X] Branch name contain the Jira key
- [X] PR title is compliant with the standard
- [X] OpenAPI spec updated (if required)


[PIN-9742]: https://pagopa.atlassian.net/browse/PIN-9742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ