### PR TITLE
fix(PIN-9335): replace tracing state ERROR with FAILED in logs 

### DIFF
--- a/packages/commons/src/logging/logger.ts
+++ b/packages/commons/src/logging/logger.ts
@@ -59,7 +59,17 @@ const logFormat = (
     .filter((e) => e !== undefined)
     .join(" ");
 
-  return `${firstPart} - ${secondPart} ${msg}`.replace(/\s+/g, " ");
+  // Sanitize the resource state "ERROR" → "FAILED" in log messages to avoid false CloudWatch alarms.
+  // Tracing state is always uppercase (e.g. states=ERROR, "state":"ERROR"), so we match uppercase only.
+  // A broader alternative would be /\bERROR\b/g, but that risks replacing unrelated occurrences
+  // (e.g. error messages, exception strings). This targeted regex is safer.
+  // Since we only replace inside `msg` (not `level`), Winston's own "error" log level label
+  // (which becomes "ERROR" in firstPart) is intentionally left untouched.
+  const sanitizedMsg = msg
+    .replace(/\bstates?=ERROR\b/g, (m) => m.replace("ERROR", "FAILED"))
+    .replace(/"state"\s*:\s*"ERROR"/g, (m) => m.replace("ERROR", "FAILED"));
+
+  return `${firstPart} - ${secondPart} ${sanitizedMsg}`.replace(/\s+/g, " ");
 };
 
 export const customFormat = () =>

--- a/packages/commons/src/logging/logger.ts
+++ b/packages/commons/src/logging/logger.ts
@@ -66,8 +66,11 @@ const logFormat = (
   // Since we only replace inside `msg` (not `level`), Winston's own "error" log level label
   // (which becomes "ERROR" in firstPart) is intentionally left untouched.
   const sanitizedMsg = msg
-    .replace(/\bstates?=ERROR\b/g, (m) => m.replace("ERROR", "FAILED"))
-    .replace(/"state"\s*:\s*"ERROR"/g, (m) => m.replace("ERROR", "FAILED"));
+    .replace(/\bstates?\s*=\s*ERROR\b/g, (m) => m.replace("ERROR", "FAILED"))
+    .replace(/"state"\s*:\s*"ERROR"/g, (m) => m.replace("ERROR", "FAILED"))
+    .replace(/"previousState"\s*:\s*"ERROR"/g, (m) =>
+      m.replace("ERROR", "FAILED"),
+    );
 
   return `${firstPart} - ${secondPart} ${sanitizedMsg}`.replace(/\s+/g, " ");
 };

--- a/packages/state-updater/src/messagesHandler.ts
+++ b/packages/state-updater/src/messagesHandler.ts
@@ -52,7 +52,7 @@ export function processProcessingResultMessage(
       await service.updateTracingState(result);
 
       logger(ctx).info(
-        `Updating tracing state to "${result.state}" for tracingId: ${result.tracingId}, version: ${result.version}`,
+        `Updating tracing {"state":"${result.state}"} for tracingId: ${result.tracingId}, version: ${result.version}`,
       );
     } catch (error: unknown) {
       throw errorMapper(


### PR DESCRIPTION
## Jira Issue
[PIN-9335](https://pagopa.atlassian.net/browse/PIN-9335)

## Context/Why
- Replace all internal occurrences of the tracing state `ERROR` with `FAILED` in application logs to avoid false CloudWatch alarms triggered by the presence of the word "ERROR" in log lines
- The state `ERROR` refers to a user-submitted CSV containing invalid rows — it is not a server error, so it must not appear as such in observability tooling
- The public API response (`GET /tracings`) continues to return `ERROR` as the tracing state to preserve backward compatibility with existing clients; no changes to the OpenAPI spec are required

## Services Impacted
- commons

## Key Changes
- Added targeted sanitization in `logFormat` (`commons/logger.ts`): replaces `ERROR` → `FAILED` in the log message body only, using specific patterns (`states=ERROR`, `"state":"ERROR"`) rather than a broad `/\bERROR\b/g` to avoid unintended replacements in exception strings or other message content
- Sanitization is applied exclusively to `msg`, leaving Winston's own `error` log level label (`ERROR` in the log prefix) intentionally untouched


## Traceability Checklist
- [x] Branch name contains the Jira key
- [x] PR title is compliant with the standard


## Smoke screen

#### ?states=ERROR
<img width="899" height="39" alt="Screenshot 2026-04-15 alle 12 00 12" src="https://github.com/user-attachments/assets/a2ea245f-232e-4535-96cb-ecaf07b388ed" />

#### ?states=ERROR,COMPLETED
<img width="1046" height="40" alt="Screenshot 2026-04-15 alle 11 59 52" src="https://github.com/user-attachments/assets/bbcb01e0-7bdd-4ece-81ae-9445e4b2ab2a" />


[PIN-9335]: https://pagopa.atlassian.net/browse/PIN-9335
