### PR TITLE
fix(PIN-9601): set COPY NULL marker state-updater

### DIFF
--- a/packages/state-updater/src/services/db/dbService.ts
+++ b/packages/state-updater/src/services/db/dbService.ts
@@ -29,7 +29,8 @@ export function dbServiceBuilder(db: DB) {
       const purposeErrorCsvColumns = Object.keys(errorsCsvMapping);
       const table = `${config.dbSchemaName}.purposes_errors`;
       const columns = purposeErrorCsvColumns.join(",");
-      const copyQuery = `COPY ${table} (${columns}) FROM STDIN WITH (FORMAT csv, HEADER true)`;
+      // Keep empty CSV fields as empty strings (not NULL) to satisfy NOT NULL columns.
+      const copyQuery = `COPY ${table} (${columns}) FROM STDIN WITH (FORMAT csv, HEADER true, NULL '\\\\N')`;
 
       const deleteQuery = `
         DELETE FROM ${config.dbSchemaName}.purposes_errors


### PR DESCRIPTION
## Jira Issue
[PIN-9601](https://pagopa.atlassian.net/browse/PIN-9601)

## Context/Why
- The `state-updater` COPY into `purposes_errors` was failing when the errors CSV contained empty fields (e.g. `purpose_id` for global CSV errors like invalid headers).
- Configure COPY to treat only `\N` as NULL, so empty CSV fields are persisted as empty strings and NOT NULL constraints are not violated.

## Services Impacted
- state-updater

## Key Changes
 - Update `COPY ... CSV` options to use `NULL '\N'` so empty CSV fields are not interpreted as NULL

## Traceability Checklist
- [x] Branch name contain the Jira key
- [x] PR title is compliant with the standard
