### PR TITLE
feat: add uriErrorHandlerMiddleware to handle URIerrors and return 400

### DIFF
--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -17,6 +17,7 @@ import {
 } from "./services/operationsService.js";
 import { configureMulterEndpoints } from "./routers/config/multer.js";
 import { queryParamsMiddleware } from "./middlewares/query.js";
+import { uriErrorHandlerMiddleware } from "./middlewares/uriErrorHandlerMiddleware.js";
 import { ZodiosApp } from "@zodios/express";
 import { ApiExternal } from "./model/types.js";
 import { LocalExpressContext, localZodiosCtx } from "./context/index.js";
@@ -80,5 +81,7 @@ app.use(authenticationMiddleware);
 
 configureMulterEndpoints(app);
 app.use(tracingRouter(localZodiosCtx)(operationsService, fileManager));
+
+app.use(uriErrorHandlerMiddleware);
 
 export default app;

--- a/packages/api/src/middlewares/uriErrorHandlerMiddleware.ts
+++ b/packages/api/src/middlewares/uriErrorHandlerMiddleware.ts
@@ -1,0 +1,16 @@
+import { NextFunction, Request, Response } from "express";
+import { genericLogger } from "pagopa-interop-tracing-commons";
+
+export function uriErrorHandlerMiddleware(
+  err: Error,
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  if (err instanceof URIError) {
+    genericLogger.warn(`Invalid URL encoding: ${req.originalUrl}`);
+    res.status(400).send("Bad Request");
+    return;
+  }
+  next(err);
+}

--- a/packages/api/src/middlewares/uriErrorHandlerMiddleware.ts
+++ b/packages/api/src/middlewares/uriErrorHandlerMiddleware.ts
@@ -1,5 +1,14 @@
 import { NextFunction, Request, Response } from "express";
+import { constants } from "http2";
 import { genericLogger } from "pagopa-interop-tracing-commons";
+import {
+  badRequestError,
+  generateId,
+  makeApiProblemBuilder,
+  CorrelationId,
+} from "pagopa-interop-tracing-models";
+
+const makeApiProblem = makeApiProblemBuilder({});
 
 export function uriErrorHandlerMiddleware(
   err: Error,
@@ -9,7 +18,13 @@ export function uriErrorHandlerMiddleware(
 ): void {
   if (err instanceof URIError) {
     genericLogger.warn(`Invalid URL encoding: ${req.originalUrl}`);
-    res.status(400).send("Bad Request");
+    const problem = makeApiProblem(
+      badRequestError(`Invalid URL encoding: ${req.originalUrl}`),
+      () => constants.HTTP_STATUS_BAD_REQUEST,
+      genericLogger,
+      generateId<CorrelationId>(),
+    );
+    res.status(problem.status).json(problem).end();
     return;
   }
   next(err);

--- a/packages/api/test/router.test.ts
+++ b/packages/api/test/router.test.ts
@@ -993,11 +993,58 @@ describe("Tracing Router", () => {
   });
 
   describe("uriErrorHandlerMiddleware", () => {
-    it("should return 400 Bad Request when a URIError is thrown due to invalid percent-encoding in route params", async () => {
-      const response = await tracingApiClient.get("/tracings/%c0/errors");
+    const malformedEncodings = ["%c0", "%a", "%zz"];
 
-      expect(response.status).toBe(400);
-      expect(response.text).toBe("Bad Request");
+    describe("GET requests", () => {
+      it.each(malformedEncodings)(
+        "should return 400 JSON problem for GET /tracings/%s/errors",
+        async (encoded) => {
+          const response = await tracingApiClient.get(
+            `/tracings/${encoded}/errors`,
+          );
+
+          expect(response.status).toBe(400);
+          expect(response.body).toMatchObject({
+            type: "about:blank",
+            status: 400,
+            title: "Bad request",
+          });
+        },
+      );
+    });
+
+    describe("POST requests", () => {
+      it.each(malformedEncodings)(
+        "should return 400 JSON problem for POST /tracings/%s/recover",
+        async (encoded) => {
+          const response = await tracingApiClient.post(
+            `/tracings/${encoded}/recover`,
+          );
+
+          expect(response.status).toBe(400);
+          expect(response.body).toMatchObject({
+            type: "about:blank",
+            status: 400,
+            title: "Bad request",
+          });
+        },
+      );
+
+      it.each(malformedEncodings)(
+        "should return 400 JSON problem for POST /tracings/%s/replace",
+        async (encoded) => {
+          const response = await tracingApiClient.post(
+            `/tracings/${encoded}/replace`,
+          );
+
+          expect(response.status).toBe(400);
+          expect(response.body).toMatchObject({
+            type: "about:blank",
+            status: 400,
+            title: "Bad request",
+          });
+        },
+      );
     });
   });
 });

--- a/packages/api/test/router.test.ts
+++ b/packages/api/test/router.test.ts
@@ -56,6 +56,7 @@ import {
 } from "../src/model/types.js";
 import { configureMulterEndpoints } from "../src/routers/config/multer.js";
 import { LocalExpressContext, localZodiosCtx } from "../src/context/index.js";
+import { uriErrorHandlerMiddleware } from "../src/middlewares/uriErrorHandlerMiddleware.js";
 
 const operationsApiClient = createApiClient(config.operationsBaseUrl);
 const operationsService: OperationsService =
@@ -89,6 +90,7 @@ const mockAuthenticationMiddleware = (
 
 app.use(mockAuthenticationMiddleware);
 app.use(tracingRouter(localZodiosCtx)(operationsService, fileManager));
+app.use(uriErrorHandlerMiddleware);
 
 const tracingApiClient = supertest(app);
 
@@ -987,6 +989,15 @@ describe("Tracing Router", () => {
 
       expect(response.text).contains("Unexpected error");
       expect(response.status).toBe(500);
+    });
+  });
+
+  describe("uriErrorHandlerMiddleware", () => {
+    it("should return 400 Bad Request when a URIError is thrown due to invalid percent-encoding in route params", async () => {
+      const response = await tracingApiClient.get("/tracings/%c0/errors");
+
+      expect(response.status).toBe(400);
+      expect(response.text).toBe("Bad Request");
     });
   });
 });


### PR DESCRIPTION
[PIN-6581](https://pagopa.atlassian.net/browse/PIN-6581)

This pull request introduces a new middleware for URI errors handling in the API, ensuring that requests with invalid URL encoding are properly caught and responded to with a 400 Bad Request. 
The middleware is added to both the application and its test suite, and new tests are included to verify the correct behavior.

**Error handling improvements:**

* Added a new `uriErrorHandlerMiddleware` in `uriErrorHandlerMiddleware.ts` that catches `URIError` exceptions, logs a warning, and returns a 400 Bad Request response.
* Integrated `uriErrorHandlerMiddleware` into the main Express app in `app.ts` to handle malformed URLs globally.

**Testing enhancements:**

* Added the `uriErrorHandlerMiddleware` to the test app setup in `router.test.ts` to ensure consistent error handling during tests. 
* Introduced a new test case in `router.test.ts` to verify that requests with invalid percent-encoding trigger a 400 Bad Request response.

[PIN-6581]: https://pagopa.atlassian.net/browse/PIN-6581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ