### PR TITLE
align(PIN-9742): remove severity query from getTracings

### DIFF
--- a/packages/api/open-api/api-external-interop-v1.yaml
+++ b/packages/api/open-api/api-external-interop-v1.yaml
@@ -96,14 +96,6 @@ paths:
             format: int32
             minimum: 1
             maximum: 50
-        - in: query
-          name: severity
-          required: false
-          schema:
-            type: string
-            enum:
-              - INVALID
-              - WARNING
       responses:
         "200":
           description: Successful response


### PR DESCRIPTION
## Jira Issue
[PIN-9742](https://pagopa.atlassian.net/browse/PIN-9742)

## Context/Why
- OpenAPI alignment: `severity` was mistakenly added to `GET /tracings`
- The `severity` filter is only meant for `GET /tracings/{tracingId}/errors`, so the external API client was generated with an inconsistent signature

## Services Impacted
- tracing-api

## Key Changes
- Removed the `severity` query param from `GET /tracings` in `packages/api/open-api/api-external-interop-v1.yaml`

## Traceability Checklist
- [x] Branch name contain the Jira key
- [x] PR title is compliant with the standard
- [x] OpenAPI spec updated (if required)

[PIN-9742]: https://pagopa.atlassian.net/browse/PIN-9742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ