### PR TITLE
chore(PIN-9994): bump interop-outbound-models to 1.8.16

### DIFF
--- a/packages/delegation-event-consumer/package.json
+++ b/packages/delegation-event-consumer/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@pagopa/interop-outbound-models": "1.8.10",
+    "@pagopa/interop-outbound-models": "1.8.16",
     "@zodios/core": "10.9.6",
     "dotenv-flow": "3.3.0",
     "kafka-connector": "workspace:*",

--- a/packages/eservice-event-consumer/package.json
+++ b/packages/eservice-event-consumer/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@pagopa/interop-outbound-models": "1.8.10",
+    "@pagopa/interop-outbound-models": "1.8.16",
     "@tsconfig/node-lts": "20.1.0",
     "@zodios/core": "10.9.6",
     "axios": "1.6.7",

--- a/packages/eservice-event-consumer/src/handlers/messageHandlerV2.ts
+++ b/packages/eservice-event-consumer/src/handlers/messageHandlerV2.ts
@@ -97,6 +97,13 @@ export async function handleMessageV2(
           "EServicePersonalDataFlagUpdatedAfterPublication",
           "EServicePersonalDataFlagUpdatedByTemplateUpdate",
           "EServiceInstanceLabelUpdated",
+          "EServiceArchivingScheduled",
+          "EServiceArchivingCanceled",
+          "EServiceArchivingCompleted",
+          "EServiceDescriptorArchivingScheduled",
+          "EServiceDescriptorArchivingCanceled",
+          "EServiceDescriptorArchivingCompleted",
+          "MaintenanceEServicePersonalDataFlagReset",
         ),
       },
       async (evt) => {

--- a/packages/kafka-producer/package.json
+++ b/packages/kafka-producer/package.json
@@ -23,7 +23,7 @@
     "zod": "3.23.8"
   },
   "devDependencies": {
-    "@pagopa/interop-outbound-models": "1.8.10",
+    "@pagopa/interop-outbound-models": "1.8.16",
     "@types/express": "4.17.17",
     "@types/node": "20.10.0",
     "@typescript-eslint/eslint-plugin": "8.22.0",

--- a/packages/purpose-event-consumer/package.json
+++ b/packages/purpose-event-consumer/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@pagopa/interop-outbound-models": "1.8.10",
+    "@pagopa/interop-outbound-models": "1.8.16",
     "@zodios/core": "10.9.6",
     "dotenv-flow": "3.3.0",
     "kafka-connector": "workspace:*",

--- a/packages/tenant-event-consumer/package.json
+++ b/packages/tenant-event-consumer/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@pagopa/interop-outbound-models": "1.8.10",
+    "@pagopa/interop-outbound-models": "1.8.16",
     "@zodios/core": "10.9.6",
     "dotenv-flow": "3.3.0",
     "kafka-connector": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -352,8 +352,8 @@ importers:
   packages/delegation-event-consumer:
     dependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.8.10
-        version: 1.8.10
+        specifier: 1.8.16
+        version: 1.8.16
       '@tsconfig/node-lts':
         specifier: 20.1.0
         version: 20.1.0
@@ -513,8 +513,8 @@ importers:
   packages/eservice-event-consumer:
     dependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.8.10
-        version: 1.8.10
+        specifier: 1.8.16
+        version: 1.8.16
       '@tsconfig/node-lts':
         specifier: 20.1.0
         version: 20.1.0
@@ -642,8 +642,8 @@ importers:
         version: 3.23.8
     devDependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.8.10
-        version: 1.8.10
+        specifier: 1.8.16
+        version: 1.8.16
       '@types/express':
         specifier: 4.17.17
         version: 4.17.17
@@ -995,8 +995,8 @@ importers:
   packages/purpose-event-consumer:
     dependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.8.10
-        version: 1.8.10
+        specifier: 1.8.16
+        version: 1.8.16
       '@tsconfig/node-lts':
         specifier: 20.1.0
         version: 20.1.0
@@ -1156,8 +1156,8 @@ importers:
   packages/tenant-event-consumer:
     dependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.8.10
-        version: 1.8.10
+        specifier: 1.8.16
+        version: 1.8.16
       '@tsconfig/node-lts':
         specifier: 20.1.0
         version: 20.1.0
@@ -1857,8 +1857,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@pagopa/interop-outbound-models@1.8.10':
-    resolution: {integrity: sha512-amx3SsrQG06QmV1uS5uchpjs8midHoY8T4mvly6sBKCDIfgUto5M/JH+6O2PqoO6FGMSponOTfKWO5O/y5X75w==}
+  '@pagopa/interop-outbound-models@1.8.16':
+    resolution: {integrity: sha512-8CGChz2HuYK6U3fd2/wIC2M8xECGjbRH9EdeuBxBmaNE8bVcj9rLQQRCtPBW8r5hbvKtjjIjQ4qDQdMVn+whdg==}
 
   '@pkgr/core@0.1.2':
     resolution: {integrity: sha512-fdDH1LSGfZdTH2sxdpVMw31BanV28K/Gry0cVFxaNP77neJSkd82mM8ErPNYs9e+0O7SdHBLTDzDgwUuy18RnQ==}
@@ -3128,6 +3128,7 @@ packages:
 
   formidable@2.1.2:
     resolution: {integrity: sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==}
+    deprecated: 'ACTION REQUIRED: SWITCH TO v3 - v1 and v2 are VULNERABLE! v1 is DEPRECATED FOR OVER 2 YEARS! Use formidable@latest or try formidable-mini for fresh projects'
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -3549,6 +3550,7 @@ packages:
   multer@1.4.5-lts.1:
     resolution: {integrity: sha512-ywPWvcDMeH+z9gQq5qYHCCy+ethsk4goepZ45GLD63fOu0YcNecQxi64nDs3qluZB+murG3/D4dJ7+dGctcCQQ==}
     engines: {node: '>= 6.0.0'}
+    deprecated: Multer 1.x is impacted by a number of vulnerabilities, which have been patched in 2.x. You should upgrade to the latest 2.x version.
 
   nan@2.22.2:
     resolution: {integrity: sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==}
@@ -4033,11 +4035,12 @@ packages:
   superagent@8.1.2:
     resolution: {integrity: sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==}
     engines: {node: '>=6.4.0 <13 || >=14'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
 
   supertest@6.3.4:
     resolution: {integrity: sha512-erY3HFDG0dPnhw4U+udPfrzXa4xhSG+n4rxfRuZWCUvjFWwKl+OxWf/7zk50s84/fAAs7vf5QAb9uRa0cCykxw==}
     engines: {node: '>=6.4.0'}
+    deprecated: Please upgrade to supertest v7.1.3+, see release notes at https://github.com/forwardemail/supertest/releases/tag/v7.1.3 - maintenance is supported by Forward Email @ https://forwardemail.net
 
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
@@ -5689,7 +5692,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@pagopa/interop-outbound-models@1.8.10':
+  '@pagopa/interop-outbound-models@1.8.16':
     dependencies:
       '@protobuf-ts/runtime': 2.9.4
       ts-pattern: 5.2.0


### PR DESCRIPTION
## Jira Issue
[PIN-9994](https://pagopa.atlassian.net/browse/PIN-9994)

## Context/Why
- Updated `@pagopa/interop-outbound-models` to `1.8.16` to align consumers/producer with the latest outbound event models.
- Fixed `eservice-event-consumer `build after the upgrade by handling newly introduced V2 event types.

## Services Impacted
- pagopa-interop-tracing-purpose-event-consumer
- pagopa-interop-tracing-eservice-event-consumer
- pagopa-interop-tracing-delegation-event-consumer
- pagopa-interop-tracing-tenant-event-consumer
- pagopa-interop-tracing-kafka-producer

## Key Changes
- Bumped `@pagopa/interop-outbound-models` from `1.8.10` to `1.8.16` in impacted packages.
- Updated `pnpm-lock.yaml` accordingly.
- Updated `eservice-event-consumer` V2 handler to explicitly skip newly added outbound event types to keep ts-pattern matching exhaustive.

## Traceability Checklist
- [x] Branch name contain the Jira key
- [x] PR title is compliant with the standard

[PIN-9994]: https://pagopa.atlassian.net/browse/PIN-9994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ