### PR TITLE
hotfix: update missing log formatting from 'ERROR' to 'FAILED'

### DIFF
--- a/packages/commons/src/logging/logger.ts
+++ b/packages/commons/src/logging/logger.ts
@@ -66,7 +66,9 @@ const logFormat = (
   // Since we only replace inside `msg` (not `level`), Winston's own "error" log level label
   // (which becomes "ERROR" in firstPart) is intentionally left untouched.
   const sanitizedMsg = msg
-    .replace(/\bstates?\s*=\s*ERROR\b/g, (m) => m.replace("ERROR", "FAILED"))
+    .replace(/\bstates?(?:\[\])?\s*=\s*[A-Z_,]*\bERROR\b[A-Z_,]*/g, (m) =>
+      m.replace(/\bERROR\b/g, "FAILED"),
+    )
     .replace(/"state"\s*:\s*"ERROR"/g, (m) => m.replace("ERROR", "FAILED"))
     .replace(/"previousState"\s*:\s*"ERROR"/g, (m) =>
       m.replace("ERROR", "FAILED"),


### PR DESCRIPTION
[PIN-10007](https://pagopa.atlassian.net/browse/PIN-10007)

This pull request updates the log message sanitization logic in `logger.ts` to more robustly replace occurrences of the string `ERROR` with `FAILED` in state-related log entries. This ensures that all variations of state logs containing `ERROR` are consistently sanitized.

**Logging improvements:**

* Enhanced the regular expression in `logFormat` to replace all instances of `ERROR` with `FAILED` in state-related log messages, including those with array notation or additional state values (e.g., `states=RUNNING,ERROR,FINISHED`, `states[]=ERROR`).

[PIN-10007]: https://pagopa.atlassian.net/browse/PIN-10007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ