### PR TITLE
Hotfix: (PIN-10007) gestione casi mancanti stringa error nelle chiamate

### DIFF
--- a/packages/commons/src/logging/logger.ts
+++ b/packages/commons/src/logging/logger.ts
@@ -66,7 +66,9 @@ const logFormat = (
   // Since we only replace inside `msg` (not `level`), Winston's own "error" log level label
   // (which becomes "ERROR" in firstPart) is intentionally left untouched.
   const sanitizedMsg = msg
-    .replace(/\bstates?\s*=\s*ERROR\b/g, (m) => m.replace("ERROR", "FAILED"))
+    .replace(/\bstates?(?:\[\])?\s*=\s*[A-Z_,]*\bERROR\b[A-Z_,]*/g, (m) =>
+      m.replace(/\bERROR\b/g, "FAILED"),
+    )
     .replace(/"state"\s*:\s*"ERROR"/g, (m) => m.replace("ERROR", "FAILED"))
     .replace(/"previousState"\s*:\s*"ERROR"/g, (m) =>
       m.replace("ERROR", "FAILED"),

--- a/packages/commons/src/logging/logger.ts
+++ b/packages/commons/src/logging/logger.ts
@@ -66,8 +66,9 @@ const logFormat = (
   // Since we only replace inside `msg` (not `level`), Winston's own "error" log level label
   // (which becomes "ERROR" in firstPart) is intentionally left untouched.
   const sanitizedMsg = msg
-    .replace(/\bstates?(?:\[\])?\s*=\s*[A-Z_,]*\bERROR\b[A-Z_,]*/g, (m) =>
-      m.replace(/\bERROR\b/g, "FAILED"),
+    .replace(
+      /(?<![A-Za-z])states?(?:\[\])?\s*=\s*[A-Z_,]*\bERROR\b[A-Z_,]*/g,
+      (m) => m.replace(/\bERROR\b/g, "FAILED"),
     )
     .replace(/"state"\s*:\s*"ERROR"/g, (m) => m.replace("ERROR", "FAILED"))
     .replace(/"previousState"\s*:\s*"ERROR"/g, (m) =>


### PR DESCRIPTION
This pull request updates the log message sanitization logic in the `logger.ts` file to more robustly replace occurrences of the word "ERROR" with "FAILED" in certain state-related log messages. The main change improves the regular expression used for matching, making it more flexible and accurate.

Log message sanitization improvements:

* Enhanced the regular expression in the `logFormat` function to match more variations of state assignments containing "ERROR" (e.g., `state = ERROR`, `states[] = ERROR,ERROR`, etc.), and to replace all occurrences of "ERROR" with "FAILED" in those contexts.