### PR TITLE
Hotfix: (PIN-10007) gestione casi mancanti stringa error nelle chiamate

### DIFF
--- a/packages/commons/src/logging/logger.ts
+++ b/packages/commons/src/logging/logger.ts
@@ -66,7 +66,9 @@ const logFormat = (
   // Since we only replace inside `msg` (not `level`), Winston's own "error" log level label
   // (which becomes "ERROR" in firstPart) is intentionally left untouched.
   const sanitizedMsg = msg
-    .replace(/\bstates?\s*=\s*ERROR\b/g, (m) => m.replace("ERROR", "FAILED"))
+    .replace(/\bstates?(?:\[\])?\s*=\s*[A-Z_,]*\bERROR\b[A-Z_,]*/g, (m) =>
+      m.replace(/\bERROR\b/g, "FAILED"),
+    )
     .replace(/"state"\s*:\s*"ERROR"/g, (m) => m.replace("ERROR", "FAILED"))
     .replace(/"previousState"\s*:\s*"ERROR"/g, (m) =>
       m.replace("ERROR", "FAILED"),

--- a/packages/commons/src/logging/logger.ts
+++ b/packages/commons/src/logging/logger.ts
@@ -66,8 +66,9 @@ const logFormat = (
   // Since we only replace inside `msg` (not `level`), Winston's own "error" log level label
   // (which becomes "ERROR" in firstPart) is intentionally left untouched.
   const sanitizedMsg = msg
-    .replace(/\bstates?(?:\[\])?\s*=\s*[A-Z_,]*\bERROR\b[A-Z_,]*/g, (m) =>
-      m.replace(/\bERROR\b/g, "FAILED"),
+    .replace(
+      /(?<![A-Za-z])states?(?:\[\])?\s*=\s*[A-Z_,]*\bERROR\b[A-Z_,]*/g,
+      (m) => m.replace(/\bERROR\b/g, "FAILED"),
     )
     .replace(/"state"\s*:\s*"ERROR"/g, (m) => m.replace("ERROR", "FAILED"))
     .replace(/"previousState"\s*:\s*"ERROR"/g, (m) =>

--- a/packages/commons/src/logging/loggerMiddleware.ts
+++ b/packages/commons/src/logging/loggerMiddleware.ts
@@ -3,9 +3,20 @@ import { ServiceContext } from "../context/context.js";
 import { LoggerMetadata, logger } from "./index.js";
 import { AuthData } from "../auth/index.js";
 
+const safeDecodeUrl = (url: string): string => {
+  try {
+    return decodeURI(url);
+  } catch {
+    return url;
+  }
+};
+
 export function loggerMiddleware(serviceName: string): express.RequestHandler {
   return (req, res, next): void => {
-    logger({ serviceName }).info(`Incoming Request: ${req.method} ${req.url}`);
+    const decodedUrl = safeDecodeUrl(req.url);
+    logger({ serviceName }).info(
+      `Incoming Request: ${req.method} ${decodedUrl}`,
+    );
     const context = (
       req as express.Request & {
         ctx?: ServiceContext<{
@@ -27,7 +38,7 @@ export function loggerMiddleware(serviceName: string): express.RequestHandler {
 
     res.on("finish", () => {
       loggerInstance.info(
-        `Request ${req.method} ${req.url} - Response ${res.statusCode} ${res.statusMessage}`,
+        `Request ${req.method} ${decodedUrl} - Response ${res.statusCode} ${res.statusMessage}`,
       );
     });
 


### PR DESCRIPTION
[PIN-10007](https://pagopa.atlassian.net/browse/PIN-10007)

This pull request improves the logging system in the `packages/commons` package by enhancing the way URLs are handled and refining state label replacements in logs. The main changes focus on making logs more readable and robust by safely decoding URLs and improving pattern matching for error states.

**Logging improvements:**

* `loggerMiddleware.ts`: Added a `safeDecodeUrl` function to safely decode request URLs before logging, preventing errors from malformed URLs and ensuring logs are more readable. All log entries for incoming requests and responses now use the decoded URL. 

**Log formatting enhancements:**

* `logger.ts`: Improved the regular expression in the `logFormat` function to more accurately match and replace "ERROR" with "FAILED" in state log messages, reducing the risk of false positives.

[PIN-10007]: https://pagopa.atlassian.net/browse/PIN-10007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ