### PR TITLE
PIN-10168 — Stop logging WARN-level entries on `stderr` / CloudWatch noise

### DIFF
--- a/packages/commons/src/logging/logger.ts
+++ b/packages/commons/src/logging/logger.ts
@@ -73,7 +73,8 @@ const logFormat = (
     .replace(/"state"\s*:\s*"ERROR"/g, (m) => m.replace("ERROR", "FAILED"))
     .replace(/"previousState"\s*:\s*"ERROR"/g, (m) =>
       m.replace("ERROR", "FAILED"),
-    );
+    )
+    .replace(/\bERROR or MISSING\b/g, "FAILED or MISSING");
 
   return `${firstPart} - ${secondPart} ${sanitizedMsg}`.replace(/\s+/g, " ");
 };
@@ -82,7 +83,7 @@ export const customFormat = () =>
   winston.format.printf(({ level, message, timestamp, ...meta }) => {
     if (!meta.loggerMetadata) {
       // eslint-disable-next-line no-console
-      console.warn(`[WARN] loggerMetadata not found for message: ${message}`);
+      console.log(`[WARN] loggerMetadata not found for message: ${message}`);
     }
     const lines = `${message}`
       .toString()


### PR DESCRIPTION
[PIN-10168](https://pagopa.atlassian.net/browse/PIN-10168) 

## Context

In production, CloudWatch alarms have been firing on log entries that are not real errors. The alarm rule is:

```
fields @timestamp, @message
| sort @timestamp desc
| filter (@message like /ERROR/ or stream = "stderr")
| filter @logStream not like /adot-collector/
```

So any log line that **either** contains the substring `ERROR` (case-sensitive) **or** is written to `stderr` is treated as an alarm. We observed two recurring false positives:

### Group A — Business 409 logged as WARN

`tracing-be-api` and `tracing-be-operations` log entries like:

```
WARN [tracing-api] - [OID=…] [CID=…] - title: Tracing cannot be updated
- detail: Tracing with Id … cannot be updated. The state of tracing must be either ERROR or MISSING.
- errors: …
- original error: AxiosError: Request failed with status code 409
```

These go to `stdout` (correct) but contain the standalone uppercase word `ERROR` inside the prose of the problem detail, which trips `@message like /ERROR/`. They are legitimate business 409s (a client tried to recover/replace a tracing whose state is not allowed), not real errors.

The pre-existing sanitization in `logFormat` (introduced by PIN-9335) already rewrites `ERROR` → `FAILED` for structured patterns (`state=ERROR`, `"state":"ERROR"`, `"previousState":"ERROR"`), but it was deliberately conservative and did not cover natural-language prose.

### Group B — Internal logger warning on `stderr`

The custom Winston printf format prints an internal warning when `loggerMetadata` is missing on the info object:

```ts
console.warn(`[WARN] loggerMetadata not found for message: ${message}`);
```

`console.warn` in Node.js writes to **`stderr`**, so this trips the `stream = "stderr"` clause of the alarm. In production this fires on malformed URL requests like `GET /%c0` that go through the `loggerMiddleware` + `uriErrorHandlerMiddleware` chain.

## Changes

### `packages/commons/src/logging/logger.ts`

1. **Route the internal "loggerMetadata not found" warning to stdout.** Replaced `console.warn` with `console.log` (the message text still contains the `[WARN]` prefix for grep-ability). This is the only `console.warn` call in the codebase, so the change is localized.
2. **Extend the `ERROR → FAILED` sanitization** with one additional `.replace()` in the `logFormat` chain that catches the natural-language pattern `ERROR or MISSING` and rewrites it to `FAILED or MISSING`. Kept narrow on purpose, in line with the existing conservative regex style — the comment above the chain already explains why a broad `\bERROR\b` replacement is avoided.

The actual problem detail returned in the 409 response is **unchanged**: the message the API exposes to clients still reads `… must be either ERROR or MISSING.`, which matches the real `TracingState` enum value (`ERROR`) and stays informative for whoever consumes the API. Only the log line is sanitized.


## Considerations / follow-up

The current approach (sanitization regexes + per-call-site stream discipline) is a tactical fix and is starting to accumulate cost:

- **The CloudWatch alarm rule is structurally wrong.** Matching `@message like /ERROR/` on the raw log line conflates three different things: the log level produced by Winston (`firstPart` becomes `… ERROR …` for `logger.error` calls), the value of the `TracingState` enum (`"ERROR"`), and any user-facing prose that happens to contain the word. Every new wording or new field that surfaces the state forces another targeted regex in `logFormat`.
- **`stream = "stderr"` is also a proxy, not a contract.** Today it works only because we route `error`-level Winston output to stderr and everything else to stdout. As soon as a dependency writes directly to `process.stderr` (uncaught exceptions, third-party libraries, native Node warnings), the alarm fires for non-errors.

A cleaner long-term direction, to be applied **consistently across all PagoPA interop services**, would be:

1. **Emit logs as structured JSON** (one JSON object per line) with an explicit `level` field (e.g. `level=ERROR`, `level=WARN`, `level=INFO`) and the human-readable text in a separate `message` field.
2. **Drive the CloudWatch alarm off the explicit `level` field**, e.g.:
   ```
   filter level = "ERROR"
   ```
   This eliminates the entire category of false positives caused by the word "ERROR" appearing in prose, state values, exception class names, etc., and removes the need for any sanitization regex in the logger.
3. **Drop the `stream = "stderr"` clause** (or keep it only as a secondary safety net for unhandled runtime panics, scoped to specific known patterns).
4. **Apply the same logger contract to every interop project** so the CloudWatch rules can be unified and the on-call team can rely on a single, predictable filter shape.

This requires coordination across teams (logger library + CloudWatch alarm configuration + dashboards) and is out of scope for this hotfix, but it should be tracked as a follow-up. The current PR only stops the bleeding.


[PIN-10168]: https://pagopa.atlassian.net/browse/PIN-10168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ