### PR TITLE
chore(PIN-10344): upgrade outbound models 1.8.20

### DIFF
--- a/packages/delegation-event-consumer/package.json
+++ b/packages/delegation-event-consumer/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@pagopa/interop-outbound-models": "1.8.16",
+    "@pagopa/interop-outbound-models": "catalog:",
     "@zodios/core": "10.9.6",
     "dotenv-flow": "3.3.0",
     "kafka-connector": "workspace:*",

--- a/packages/eservice-event-consumer/package.json
+++ b/packages/eservice-event-consumer/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@pagopa/interop-outbound-models": "1.8.16",
+    "@pagopa/interop-outbound-models": "catalog:",
     "@tsconfig/node-lts": "20.1.0",
     "@zodios/core": "10.9.6",
     "axios": "1.16.0",

--- a/packages/eservice-event-consumer/src/handlers/messageHandlerV2.ts
+++ b/packages/eservice-event-consumer/src/handlers/messageHandlerV2.ts
@@ -104,6 +104,11 @@ export async function handleMessageV2(
           "EServiceDescriptorArchivingCanceled",
           "EServiceDescriptorArchivingCompleted",
           "MaintenanceEServicePersonalDataFlagReset",
+          "EServiceDescriptorAsyncExchangeCallbackInterfaceAdded",
+          "EServiceDescriptorAsyncExchangeCallbackInterfaceUpdated",
+          "EServiceDescriptorAsyncExchangeCallbackInterfaceDeleted",
+          "EServiceDescriptorAttributeDailyCallsPerConsumerUpdated",
+          "MaintenanceEServiceDescriptorUnarchived",
         ),
       },
       async (evt) => {

--- a/packages/kafka-producer/package.json
+++ b/packages/kafka-producer/package.json
@@ -23,7 +23,7 @@
     "zod": "3.23.8"
   },
   "devDependencies": {
-    "@pagopa/interop-outbound-models": "1.8.16",
+    "@pagopa/interop-outbound-models": "catalog:",
     "@types/express": "4.17.17",
     "@types/node": "20.10.0",
     "@typescript-eslint/eslint-plugin": "8.22.0",

--- a/packages/purpose-event-consumer/package.json
+++ b/packages/purpose-event-consumer/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@pagopa/interop-outbound-models": "1.8.16",
+    "@pagopa/interop-outbound-models": "catalog:",
     "@zodios/core": "10.9.6",
     "dotenv-flow": "3.3.0",
     "kafka-connector": "workspace:*",

--- a/packages/tenant-event-consumer/package.json
+++ b/packages/tenant-event-consumer/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@pagopa/interop-outbound-models": "1.8.16",
+    "@pagopa/interop-outbound-models": "catalog:",
     "@zodios/core": "10.9.6",
     "dotenv-flow": "3.3.0",
     "kafka-connector": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 catalogs:
   default:
+    '@pagopa/interop-outbound-models':
+      specifier: 1.8.20
+      version: 1.8.20
     vite:
       specifier: 6.4.3
       version: 6.4.3
@@ -367,8 +370,8 @@ importers:
   packages/delegation-event-consumer:
     dependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.8.16
-        version: 1.8.16
+        specifier: 'catalog:'
+        version: 1.8.20
       '@tsconfig/node-lts':
         specifier: 20.1.0
         version: 20.1.0
@@ -534,8 +537,8 @@ importers:
   packages/eservice-event-consumer:
     dependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.8.16
-        version: 1.8.16
+        specifier: 'catalog:'
+        version: 1.8.20
       '@tsconfig/node-lts':
         specifier: 20.1.0
         version: 20.1.0
@@ -666,8 +669,8 @@ importers:
         version: 3.23.8
     devDependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.8.16
-        version: 1.8.16
+        specifier: 'catalog:'
+        version: 1.8.20
       '@types/express':
         specifier: 4.17.17
         version: 4.17.17
@@ -1031,8 +1034,8 @@ importers:
   packages/purpose-event-consumer:
     dependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.8.16
-        version: 1.8.16
+        specifier: 'catalog:'
+        version: 1.8.20
       '@tsconfig/node-lts':
         specifier: 20.1.0
         version: 20.1.0
@@ -1198,8 +1201,8 @@ importers:
   packages/tenant-event-consumer:
     dependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.8.16
-        version: 1.8.16
+        specifier: 'catalog:'
+        version: 1.8.20
       '@tsconfig/node-lts':
         specifier: 20.1.0
         version: 20.1.0
@@ -1925,8 +1928,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@pagopa/interop-outbound-models@1.8.16':
-    resolution: {integrity: sha512-8CGChz2HuYK6U3fd2/wIC2M8xECGjbRH9EdeuBxBmaNE8bVcj9rLQQRCtPBW8r5hbvKtjjIjQ4qDQdMVn+whdg==}
+  '@pagopa/interop-outbound-models@1.8.20':
+    resolution: {integrity: sha512-cx8YNSl7FxD4za/+xgWu/ltDgc5dx8hayURi617AbBMTnas5zCfCsmyg0J0SbhwI2Xx+xs2w+PfkUnSfpSpLsg==}
 
   '@pkgr/core@0.1.2':
     resolution: {integrity: sha512-fdDH1LSGfZdTH2sxdpVMw31BanV28K/Gry0cVFxaNP77neJSkd82mM8ErPNYs9e+0O7SdHBLTDzDgwUuy18RnQ==}
@@ -5903,7 +5906,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@pagopa/interop-outbound-models@1.8.16':
+  '@pagopa/interop-outbound-models@1.8.20':
     dependencies:
       '@protobuf-ts/runtime': 2.9.4
       ts-pattern: 5.2.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,5 +2,6 @@ packages:
   - 'packages/**'
 
 catalog:
+  '@pagopa/interop-outbound-models': 1.8.20
   vite: 6.4.3
   vitest: 4.1.0


### PR DESCRIPTION
## Jira Issue
[PIN-10344](https://pagopa.atlassian.net/browse/PIN-10344)

## Context/Why
- Upgrade outbound models to support the latest compatible e-service events.
- Centralize the dependency version using the pnpm catalog.

## Services Impacted
- delegation-event-consumer
- eservice-event-consumer
- kafka-producer
- purpose-event-consumer
- tenant-event-consumer

## Key Changes
- Upgrade `@pagopa/interop-outbound-models` to `1.8.20`.
- Replace duplicated dependency versions with `catalog:` references.

## Traceability Checklist
- [x] Branch name contain the Jira key
- [x] PR title is compliant with the standard
- [x] API and integration tests updated (if required)

[PIN-10344]: https://pagopa.atlassian.net/browse/PIN-10344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ